### PR TITLE
🐛🤖 cd(bug): update api doc changes using installed github apps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,13 +137,24 @@ jobs:
       - commit-analyzer
       - package-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: "write"
+      packages: "write"
+      actions: "read"
     if: ${{ needs.package-release-prep.outputs.source-code == 'true' && needs.commit-analyzer.outputs.releasable == 'true' }}
     steps:
+      - name: 🔑 Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 🌎 Setup Node.js
         uses: actions/setup-node@v4
@@ -164,8 +175,8 @@ jobs:
 
       - name: 🔧 Configure Git
         run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "maiar-intern"
+          git config --global user.email "maiar-intern@users.noreply.github.com"
 
       - name: 🔎📦 Commit Changes on API Doc Changes
         continue-on-error: true


### PR DESCRIPTION
## Description

If you enable branch protection rules with `Require a pull request before merging > Allow specified actors to bypass required pull requests`, you can add a Github App to be authorized to push API doc updates.

Created maiar-intern Github App, installed it on UraniumCorporation org to allow access to maiar-ai repo, added secrets `APP_ID` and `APP_PRIVATE_KEY`, and install it on the `generate-docs` job to checkout the code under the bot with permissions to commit/push API doc updates

## Related Issues

Currently, it is using the default `github-actions[bot]` to commit/push API doc changes and if you enable the branch protection rule `Require a pull request before merging`, this bot cannot be added as an `Allowed specified actors to bypass required pull requests` so the workflow job will fail on this job i.e. 🔎📦 Commit Changes on API Doc Changes in https://github.com/UraniumCorporation/maiar-ai/actions/runs/13338531216/job/37258833947 

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Workflow Run demonstrating this is working - https://github.com/k3v-d3v/maiar-ai/actions/runs/13344782861/job/37273898721
Workflow File for the Workflow Run - https://github.com/k3v-d3v/maiar-ai/actions/runs/13344782861/workflow

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
