### PR TITLE
📝🔗 docs(website,other): update discord link to branded link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Be respectful, constructive, and inclusive. Follow the [Code of Conduct](https:/
 
 ## Need Help?
 
-- Join [Discord](https://discord.gg/8YFx5RwvgM)
+- Join [Discord](https://discord.gg/maiar)
 - Create [GitHub issues](https://github.com/UraniumCorporation/maiar-ai/issues)
 
 Talk to us in discussions or open an issue. Happy coding!

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -279,7 +279,7 @@ const runtime = createRuntime({
 
 - Explore the [API Reference](/api) to learn about available methods and configurations
 - Check out the Plugins Guide to learn how to extend your agent's capabilities
-- Join our Discord to get help and share your experiences
+- Join our [Discord](https://discord.gg/maiar) to get help and share your experiences
 
 ## Troubleshooting
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -9,5 +9,5 @@ Maiar is a powerful framework for building AI agents that can interact with vari
 ## Need Help?
 
 - Check out our [Getting Started](docs/getting-started) guide
-- Join our community on Discord
+- Join our community on [Discord](https://discord.gg/maiar)
 - Report issues on [GitHub](https://github.com/maiar-ai/maiar/issues)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -105,7 +105,7 @@ const config: Config = {
           items: [
             {
               label: "Discord",
-              href: "https://discord.gg/8YFx5RwvgM"
+              href: "https://discord.gg/maiar"
             },
             {
               label: "X",


### PR DESCRIPTION
## Description

Updates all discord references in `CONTRIBUTING.md` docs and website docs to reference Maiar's discord branded link 

## Related Issues

Discord references in `CONTRIBUTING.md` docs and website docs reference old discord non-branded link

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [x] Documentation updated

## How to Test

```sh
# From root directory
cd website
pnpm start
```

Hover over discord link in:
- http://localhost:3000/docs
- http://localhost:3000/docs/getting-started
- Footer

They all point to https://discord.gg/maiar

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
