### PR TITLE
📝🔗 docs(website): add whitepaper link to navbar/footer

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -81,6 +81,11 @@ const config: Config = {
           href: "https://github.com/UraniumCorporation/maiar-ai",
           label: "GitHub",
           position: "right"
+        },
+        {
+          href: "https://maiar.dev/maiar.pdf",
+          label: "Whitepaper",
+          position: "right"
         }
       ]
     },
@@ -97,6 +102,10 @@ const config: Config = {
             {
               label: "API",
               to: "/api"
+            },
+            {
+              label: "Whitepaper",
+              href: "https://maiar.dev/maiar.pdf"
             }
           ]
         },


### PR DESCRIPTION
## Description

Added whitepapers link (https://maiar.dev/maiar.pdf) in the docs website in the NavBar + Footer since it was missing

## Related Issues

Whitepapers link missing in docs website

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [x] Documentation updated

## How to Test

```sh
# From the root directory
cd website
pnpm start # or pnpm build && pnpm serve
```

- Go to http://localhost:3000/docs or any docs page
   - Hover over Whitepaper link on the NavBar on the righthand side and observe it points to https://maiar.dev/maiar.pdf
   - Hover over Whitepaper link on the Footer on the righthand side and observe it points to https://maiar.dev/maiar.pdf

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
