### PR TITLE
🏗️⚡️ cd(fix): Run prepublishOnly lifecycle script before publishing to npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,7 @@ jobs:
 
           echo "Publishing packages to NPM..."
           echo "NPM Package version $LATEST_TAG"
-          pnpm lerna publish from-git --yes --no-private --ignore-scripts --dist-tag latest --loglevel verbose
+          pnpm lerna publish from-git --yes --no-private --dist-tag latest --loglevel verbose
 
   generate-docs:
     name: 📚 Generate API Docs

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "eslint . --max-warnings 0",
     "prettier": "prettier --write .",
     "whitepaper": "mkdir -p tmp_latex && pdflatex -output-directory=tmp_latex -interaction=nonstopmode -halt-on-error maiar.tex > /dev/null 2>&1 && pdflatex -output-directory=tmp_latex -interaction=nonstopmode -halt-on-error maiar.tex > /dev/null 2>&1 && mv tmp_latex/maiar.pdf . && rm -rf tmp_latex",
-    "prepublish": "pnpm build:packages"
+    "prepublishOnly": "pnpm build:packages"
   },
   "devDependencies": {
     "@commitlint/cli": "19.6.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,8 @@
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
     "clean": "rm -rf dist",
-    "echo": "echo \"nothing\""
+    "echo": "echo \"nothing\"",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "openai": "4.82.0",

--- a/packages/memory-filesystem/package.json
+++ b/packages/memory-filesystem/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*"

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/model-ollama/package.json
+++ b/packages/model-ollama/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*"

--- a/packages/model-openai/package.json
+++ b/packages/model-openai/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-character/package.json
+++ b/packages/plugin-character/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-express/package.json
+++ b/packages/plugin-express/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-image/package.json
+++ b/packages/plugin-image/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-search/package.json
+++ b/packages/plugin-search/package.json
@@ -43,7 +43,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-telegram/package.json
+++ b/packages/plugin-telegram/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-terminal/package.json
+++ b/packages/plugin-terminal/package.json
@@ -43,7 +43,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-text/package.json
+++ b/packages/plugin-text/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-time/package.json
+++ b/packages/plugin-time/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*"

--- a/packages/plugin-websocket/package.json
+++ b/packages/plugin-websocket/package.json
@@ -42,7 +42,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",

--- a/packages/plugin-x/package.json
+++ b/packages/plugin-x/package.json
@@ -43,7 +43,8 @@
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
     "build": "tsup --config ../../tsup.config.base.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",


### PR DESCRIPTION
## Description

Runs `prepublishOnly` [lifecycle script](https://dyte.io/blog/package-json-scripts/#:~:text=lifecycle%20scripts%20are%20a%20set,json%20file%20of%20a%20Node.) before publishing to npm by adding a `prepublishOnly` script to all packages that builds the package, and removes `---ignore-scripts` flag using `lerna publish` command so it will run npm [lifecycle scripts](https://dyte.io/blog/package-json-scripts/#:~:text=lifecycle%20scripts%20are%20a%20set,json%20file%20of%20a%20Node.) `prepublishOnly` script for all packages that will be published before publishing it

## Related Issues

The `release.yaml` workflow was using `lerna publish` with `--ignore-scripts` flag that did not run the lifecycle scripts and on top of that, important lifecycle scripts such as `prepublishOnly` command that builds the package before publishing to npm is missing in all packages. This could result in human/automation error for manual deployments/pipeline runs that publish to npm

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

Run a pnpm publish dry-run 

```
pnpm publish --dry-run --loglevel=silly                                                                                                                                                     1 ↵
✔ You're on branch "lerna/run-prepublishonly-script" but your "publish-branch" is set to "master|main". Do you want to continue? (y/N) · true

> @maiar-ai/core@0.4.0 prepublishOnly /Users/knguyen/personal/kevdev/maiar-ai/packages/core
> pnpm run build


> @maiar-ai/core@0.4.0 build /Users/knguyen/personal/kevdev/maiar-ai/packages/core
> tsup --config ../../tsup.config.base.ts

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.3.6
CLI Using tsup config: /Users/knguyen/personal/kevdev/maiar-ai/tsup.config.base.ts
CLI Target: es2020
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/index.js     43.26 KB
CJS dist/index.js.map 84.62 KB
CJS ⚡️ Build success in 43ms
ESM dist/index.mjs     40.86 KB
ESM dist/index.mjs.map 84.20 KB
ESM ⚡️ Build success in 43ms
DTS Build start
DTS ⚡️ Build success in 1786ms
DTS dist/index.d.ts  12.73 KB
DTS dist/index.d.mts 12.73 KB
npm verbose cli /usr/local/bin/node /usr/local/bin/npm
npm info using npm@10.9.2
npm info using node@v22.13.1
npm silly config load:file:/usr/local/lib/node_modules/npm/npmrc
npm silly config load:file:/private/var/folders/1y/770hhf917znb_62xs1hj30wh0000gn/T/70ab1c6c96cc6ae96b9d0160f78d37c3/.npmrc
npm silly config load:file:/Users/knguyen/.npmrc
npm silly config load:file:/usr/local/etc/npmrc
npm verbose title npm publish maiar-ai-core-0.4.0.tgz
npm verbose argv "publish" "--ignore-scripts" "maiar-ai-core-0.4.0.tgz" "--dry-run" "--loglevel" "silly"
npm verbose logfile logs-max:10 dir:/Users/knguyen/.npm/_logs/2025-02-15T23_45_03_442Z-
npm verbose logfile /Users/knguyen/.npm/_logs/2025-02-15T23_45_03_442Z-debug-0.log
npm silly logfile start cleaning logs, removing 1 files
npm verbose publish [ 'maiar-ai-core-0.4.0.tgz' ]
npm silly logfile done cleaning log files
npm http cache file:/private/var/folders/1y/770hhf917znb_62xs1hj30wh0000gn/T/70ab1c6c96cc6ae96b9d0160f78d37c3/maiar-ai-core-0.4.0.tgz 0ms (cache hit)
npm notice
npm notice 📦  @maiar-ai/core@0.4.0
npm notice Tarball Contents
npm notice 1.1kB LICENSE
npm notice 4.6kB README.md
npm notice 13.0kB dist/index.d.mts
npm notice 13.0kB dist/index.d.ts
npm notice 44.3kB dist/index.js
npm notice 86.7kB dist/index.js.map
npm notice 41.8kB dist/index.mjs
npm notice 86.2kB dist/index.mjs.map
npm notice 1.5kB package.json
npm notice Tarball Details
npm notice name: @maiar-ai/core
npm notice version: 0.4.0
npm notice filename: maiar-ai-core-0.4.0.tgz
npm notice package size: 67.5 kB
npm notice unpacked size: 292.3 kB
npm notice shasum: 6cc1b77065f5f92c6a81ac5337387749143b5b3d
npm notice integrity: sha512-zsbEMI9/C0sx9[...]FF7YKhe7U+Qqw==
npm notice total files: 9
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @maiar-ai/core@0.4.0
npm verbose cwd /private/var/folders/1y/770hhf917znb_62xs1hj30wh0000gn/T/70ab1c6c96cc6ae96b9d0160f78d37c3
npm verbose os Darwin 22.1.0
npm verbose node v22.13.1
npm verbose npm  v10.9.2
npm verbose exit 0
npm info ok
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
