### PR TITLE
bug: 🐛 verify models healthcheck before bootstraping the server

### DIFF
--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -22,6 +22,8 @@ export interface ModelInterface {
    * Initialize the model with any necessary setup
    */
   init?(): Promise<void>;
+
+  checkHealth(): Promise<void>;
 }
 
 /**
@@ -80,5 +82,9 @@ export class LoggingModelDecorator implements ModelInterface {
     if (this.model.init) {
       return this.model.init();
     }
+  }
+
+  checkHealth(): Promise<void> {
+    return Promise.resolve(undefined);
   }
 }

--- a/packages/core/src/models/service.ts
+++ b/packages/core/src/models/service.ts
@@ -25,10 +25,11 @@ export class LLMService {
   private defaultModelId: string | null = null;
 
   constructor(model?: ModelProvider) {
-    log.debug({ msg: "Initializing LLM service" });
+    log.debug({ msg: `Initializing LLM service: ${model?.id}` });
     if (model) {
       this.registerModel(model, "default");
     }
+    log.info({ msg: `Initialized LLM service: ${model?.id}` });
   }
 
   /**

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -49,19 +49,6 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       });
   }
 
-  if (options.model.init) {
-    // Initialize it
-    options.model
-      .init()
-      .then(() => {
-        log.debug("LLM Model initialized successfully!");
-      })
-      .catch((err) => {
-        log.error("LLM Model failed to initialize", err);
-        throw new Error(err.message);
-      });
-  }
-
   // Do check if the healthcheck is good before bootstrapping.
   options.model
     .checkHealth()

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -49,6 +49,30 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       });
   }
 
+  if (options.model.init) {
+    // Initialize it
+    options.model
+      .init()
+      .then(() => {
+        log.debug("LLM Model initialized successfully!");
+      })
+      .catch((err) => {
+        log.error("LLM Model failed to initialize", err);
+        throw new Error(err.message);
+      });
+  }
+
+  // Do check if the healthcheck is good before bootstrapping.
+  options.model
+    .checkHealth()
+    .then(() => {
+      log.debug("LLM Model healthcheck passed!");
+    })
+    .catch((err) => {
+      log.error("LLM Model healthcheck failed", err);
+      throw new Error(err.message);
+    });
+
   // Initialize memory service with the provided provider
   const memoryService = new MemoryService(options.memory);
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -36,6 +36,19 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   // Initialize LLM service with the provided model
   const llmService = new LLMService(options.model);
 
+  if (options.model.init) {
+    // Initialize it
+    options.model
+      .init()
+      .then(() => {
+        log.debug("LLM Model initialized successfully!");
+      })
+      .catch((err) => {
+        log.error("LLM Model failed to initialize", err);
+        throw new Error(err.message);
+      });
+  }
+
   // Initialize memory service with the provided provider
   const memoryService = new MemoryService(options.memory);
 

--- a/packages/model-ollama/src/deepseek.ts
+++ b/packages/model-ollama/src/deepseek.ts
@@ -1,5 +1,6 @@
 import { ModelProvider, ModelRequestConfig } from "@maiar-ai/core";
 import { createLogger } from "@maiar-ai/core";
+import { verifyBasicHealth } from "./index";
 
 const log = createLogger("models");
 
@@ -90,42 +91,8 @@ export class DeepseekProvider implements ModelProvider {
     }
 
     try {
-      // Send a GET request to the health endpoint
-      const modelsUrl = `${this.baseUrl}/api/tags`;
-      const response = await fetch(modelsUrl, {
-        method: "GET"
-      });
-
-      // Ensure the server responded successfully
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      // Parse the JSON response
-      const data = await response.json();
-
-      // Verify that the JSON object has a 'models' array and it contains at least one element
-      if (!data || !Array.isArray(data.models) || data.models.length === 0) {
-        throw new Error(
-          "Health check failed: 'models' array is missing or empty"
-        );
-      }
-
-      // Verify that the provided this.model exists in one of the models,
-      // either as an exact match or as a model name prefixed with "deepseek-" (from above check)
-      const modelExists = data.models.some(
-        (m: { name: string; model: string }) => m.model === this.model
-      );
-
-      if (!modelExists) {
-        const availableModels = data.models
-          .map((m: { model: string }) => m.model)
-          .join(", ");
-        throw new Error(
-          `Model "${this.model}" not deployed in Ollama server. Available models: ${availableModels}`
-        );
-      }
-
+      // Send a GET request to the tag endpoint and verify if the model exists
+      await verifyBasicHealth(this.baseUrl, this.model);
       log.info({ msg: `Deepseek model '${this.model}' health check passed` });
     } catch (error) {
       log.error(

--- a/packages/model-ollama/src/deepseek.ts
+++ b/packages/model-ollama/src/deepseek.ts
@@ -80,4 +80,8 @@ export class DeepseekProvider implements ModelProvider {
   async init(): Promise<void> {
     // No initialization needed for Deepseek
   }
+
+  async checkHealth(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
 }

--- a/packages/model-ollama/src/deepseek.ts
+++ b/packages/model-ollama/src/deepseek.ts
@@ -118,8 +118,11 @@ export class DeepseekProvider implements ModelProvider {
       );
 
       if (!modelExists) {
+        const availableModels = data.models
+          .map((m: { model: string }) => m.model)
+          .join(", ");
         throw new Error(
-          `Deepseek Model "${this.model}" not deployed in Ollama server`
+          `Model "${this.model}" not deployed in Ollama server. Available models: ${availableModels}`
         );
       }
 

--- a/packages/model-ollama/src/deepseek.ts
+++ b/packages/model-ollama/src/deepseek.ts
@@ -78,7 +78,7 @@ export class DeepseekProvider implements ModelProvider {
   }
 
   async init(): Promise<void> {
-    await this.checkHealth();
+    // Nothing to implemnt
   }
 
   async checkHealth(): Promise<void> {

--- a/packages/model-ollama/src/index.ts
+++ b/packages/model-ollama/src/index.ts
@@ -1,2 +1,39 @@
 export { OllamaProvider } from "./ollama";
 export { DeepseekProvider } from "./deepseek";
+
+export async function verifyBasicHealth(
+  baseUrl: string,
+  modelNameTag: string
+): Promise<void> {
+  const modelsUrl = `${baseUrl}/api/tags`;
+  const response = await fetch(modelsUrl, {
+    method: "GET"
+  });
+
+  // Ensure the server responded successfully
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  // Parse the JSON response
+  const data = await response.json();
+
+  // Verify that the JSON object has a 'models' array and it contains at least one element
+  if (!data || !Array.isArray(data.models) || data.models.length === 0) {
+    throw new Error("Health check failed: 'models' array is missing or empty");
+  }
+
+  // Verify that the provided this.model exists in one of the models,
+  const modelExists = data.models.some(
+    (m: { name: string; model: string }) => m.model === modelNameTag
+  );
+
+  if (!modelExists) {
+    const availableModels = data.models
+      .map((m: { model: string }) => m.model)
+      .join(", ");
+    throw new Error(
+      `Model "${modelNameTag}" not deployed in Ollama server. Available models: ${availableModels}`
+    );
+  }
+}

--- a/packages/model-ollama/src/ollama.ts
+++ b/packages/model-ollama/src/ollama.ts
@@ -61,4 +61,8 @@ export class OllamaProvider implements ModelProvider {
   async init(): Promise<void> {
     // No initialization needed for Ollama
   }
+
+  async checkHealth(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
 }

--- a/packages/model-ollama/src/ollama.ts
+++ b/packages/model-ollama/src/ollama.ts
@@ -69,11 +69,9 @@ export class OllamaProvider implements ModelProvider {
   async checkHealth(): Promise<void> {
     try {
       // Send a GET request to the health endpoint
-      const response = await fetch(`${this.baseUrl}/api/models`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json"
-        }
+      const modelsUrl = `${this.baseUrl}/api/tags`;
+      const response = await fetch(modelsUrl, {
+        method: "GET"
       });
 
       // Ensure the server responded successfully
@@ -91,9 +89,21 @@ export class OllamaProvider implements ModelProvider {
         );
       }
 
-      log.info({ msg: "Ollama model health check passed" });
+      // Verify that the provided this.model exists in one of the models.
+      const modelExists = data.models.some(
+        (m: { name: string; model: string }) => m.model === this.model
+      );
+
+      if (!modelExists) {
+        throw new Error(`Model "${this.model}" not deployed in Ollama server`);
+      }
+
+      log.info({ msg: `Ollama model '${this.model}' health check passed` });
     } catch (error) {
-      log.error("Error during health check:", error);
+      log.error(
+        `Ollama model '${this.model}' health check failed: model not deployed`,
+        error
+      );
       throw error;
     }
   }

--- a/packages/model-ollama/src/ollama.ts
+++ b/packages/model-ollama/src/ollama.ts
@@ -59,7 +59,7 @@ export class OllamaProvider implements ModelProvider {
   }
 
   async init(): Promise<void> {
-    await this.checkHealth();
+    // Nothing to implemnt
   }
 
   /**

--- a/packages/model-ollama/src/ollama.ts
+++ b/packages/model-ollama/src/ollama.ts
@@ -95,7 +95,12 @@ export class OllamaProvider implements ModelProvider {
       );
 
       if (!modelExists) {
-        throw new Error(`Model "${this.model}" not deployed in Ollama server`);
+        const availableModels = data.models
+          .map((m: { model: string }) => m.model)
+          .join(", ");
+        throw new Error(
+          `Model "${this.model}" not deployed in Ollama server. Available models: ${availableModels}`
+        );
       }
 
       log.info({ msg: `Ollama model '${this.model}' health check passed` });

--- a/packages/model-openai/src/openai.ts
+++ b/packages/model-openai/src/openai.ts
@@ -47,10 +47,11 @@ export class OpenAIProvider implements ModelProvider {
   }
 
   async init(): Promise<void> {
-    await this.checkHealth();
+    // Nothing to init
   }
 
   async checkHealth(): Promise<void> {
+    // Verifying if we can call the API
     try {
       const resp = await this.getText("are you alive?", {
         temperature: 0.7

--- a/packages/model-openai/src/openai.ts
+++ b/packages/model-openai/src/openai.ts
@@ -53,9 +53,13 @@ export class OpenAIProvider implements ModelProvider {
   async checkHealth(): Promise<void> {
     // Verifying if we can call the API
     try {
-      const resp = await this.getText("are you alive?", {
-        temperature: 0.7
-      });
+      const resp = await this.getText(
+        "are you alive? Please respond 'yes' or 'no' only.",
+        {
+          temperature: 0.7,
+          maxTokens: 5
+        }
+      );
       log.debug(`checkHealth result: ${resp}`);
       log.info({ msg: `Model ${this.id} health check passed` });
     } catch (error) {

--- a/packages/model-openai/src/openai.ts
+++ b/packages/model-openai/src/openai.ts
@@ -47,6 +47,21 @@ export class OpenAIProvider implements ModelProvider {
   }
 
   async init(): Promise<void> {
-    // No initialization needed for OpenAI
+    await this.checkHealth();
+  }
+
+  async checkHealth(): Promise<void> {
+    try {
+      const resp = await this.getText("are you alive?", {
+        temperature: 0.7
+      });
+      log.debug(`checkHealth result: ${resp}`);
+      log.info({ msg: `Model ${this.id} health check passed` });
+    } catch (error) {
+      log.error({ msg: `Model ${this.id} health check failed`, error });
+      throw new Error(
+        `Failed to initialize Model ${this.id}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
   }
 }


### PR DESCRIPTION
## 📜 Description

This indirectly solves the case when a Model is misconfigured. The current implementation:

* Adds `checkHealth()` function to the interface
* Implements the function in all the current models (openAI, ollama, deepseek)
* Outputs the current list of existing models for both Ollama and deepseek when the config of the plugin is incorrect, etc.
  * For details on how to run Ollama: https://gist.github.com/marcellodesales/7be67c13d6799628dcb6954155fbd765

> [!CAUTION]
> * When an OpenAI token has no credits and the server is unable to send any requests 
> * The new log statement would show users this is a healthcheck error and they should follow the possible solutions
> ```
> [2025-02-15 18:58:40.425 -0800] ERROR: model:openai: Model openai health check failed
> ```

For this reason, this ticket supports the extension idea on `checkHealth()` function already implemented for the SQLite component, where the database is checked at bootstrap time.

## 🔢 Related Issues

* #7

## 🎛️ Changes Made

- [x] Feature added
- [x] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## ✅ How to Test

Follow the steps described at #7.

## ✔️ Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary

# 💻 OpenAPI Model

* The server now crashes before, making sure the user provides the correct token for OpenAI.
* As a consequence, the problem described in #7 wouldn't happen for the case of misconfiguration.
  * That is, we still need to solve the general case of errors not being returned to the client.
* The code tested is the current version of the `maiar-starter`

```console
omebrew/bin/pnpm start

> @maiar-ai/maiar-starter@0.0.0 start /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/maiar-starter
> node dist/index.js

Starting agent...
[Express Plugin] Starting HTTP request listener
[Express Plugin] Express middleware configured
[Express Plugin] Server is running on localhost:3000
[2025-02-15 18:58:38.067 -0800] INFO: memory:sqlite: SQLite health check passed
    component: "memory:sqlite"
[2025-02-15 18:58:38.069 -0800] INFO: models: Initialized LLM service: openai
    component: "models"
[2025-02-15 18:58:38.069 -0800] INFO: memory: Initialized memory service with provider: sqlite
    component: "memory"
[2025-02-15 18:58:38.073 -0800] INFO: memory:sqlite: Initialized SQLite memory storage
    component: "memory:sqlite"
[2025-02-15 18:58:38.083 -0800] INFO: runtime: Initialized runtime with plugins
    component: "runtime"
    plugins: [
      "plugin-express",
      "plugin-text",
      "plugin-time",
      "plugin-character",
      "plugin-search"
    ]
[2025-02-15 18:58:38.083 -0800] INFO: runtime: Starting evaluation loop
    component: "runtime"
[2025-02-15 18:58:40.425 -0800] ERROR: model:openai: Error getting text from OpenAI:
    component: "model:openai"
[2025-02-15 18:58:40.425 -0800] ERROR: model:openai: Model openai health check failed
    component: "model:openai"
    error: {
      "type": "Error",
      "message": "429 You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
      "stack":
          at APIError.generate (/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/node_modules/.pnpm/openai@4.82.0_encoding@0.1.13_ws@8.18.0_zod@3.24.1/node_modules/openai/error.js:63:20)
            at OpenAI.makeStatusError (/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/node_modules/.pnpm/openai@4.82.0_encoding@0.1.13_ws@8.18.0_zod@3.24.1/node_modules/openai/core.js:293:33)
            at OpenAI.makeRequest (/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/node_modules/.pnpm/openai@4.82.0_encoding@0.1.13_ws@8.18.0_zod@3.24.1/node_modules/openai/core.js:337:30)
            at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
            at async OpenAIProvider.getText (/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/model-openai/dist/index.js:53:26)
            at async OpenAIProvider.checkHealth (/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/model-openai/dist/index.js:75:20)
            at async OpenAIProvider.init (/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/model-openai/dist/index.js:71:5)
    }
[2025-02-15 18:58:40.426 -0800] ERROR: runtime: LLM Model failed to initialize
    component: "runtime"
/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047
      throw new Error(err.message);
            ^

Error: Failed to initialize Model openai: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.
    at /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047:13
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

Node.js v23.5.0
 ELIFECYCLE  Command failed with exit code 1.

Process finished with exit code 1
```

# 💻 Ollama Model

* For Ollama health check, we just can pull the list of models from the /api/tags
  * https://github.com/ollama/ollama/blob/main/docs/api.md#list-local-models
  * Check if the specified model is deployed in the server

> [!TIP]
> * Ollama models must be the full name: model-name:model-tag
>  * The correct name must match the version in the server
> * The new log statement would show users this is a healthcheck error and they should follow the possible solutions
> ```
> [2025-02-15 20:15:47.552 -0800] ERROR: model:ollama: Ollama model 'llama2' health check failed: model not deployed
> ```

The version tried:

```typescript
const runtime = createRuntime({
  model: new OllamaProvider({
    baseUrl: "http://localhost:11434",
    model: "llama2"
  }),
```

## 👽 Ollama Server 

* This is failing for the current ollama server with the following:

```console
$  curl -i http://localhost:11434/api/tags
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Date: Sun, 16 Feb 2025 04:12:44 GMT
Transfer-Encoding: chunked
```
```json
{
  "models": [
    {
      "name": "llama2:latest",
      "model": "llama2:latest",
      "modified_at": "2025-02-15T04:50:06.937249822Z",
      "size": 3826793677,
      "digest": "78e26419b4469263f75331927a00a0284ef6544c1975b826b15abdaef17bb962",
      "details": {
        "parent_model": "",
        "format": "gguf",
        "family": "llama",
        "families": [
          "llama"
        ],
        "parameter_size": "7B",
        "quantization_level": "Q4_0"
      }
    },
    {
      "name": "codellama:70b",
      "model": "codellama:70b",
      "modified_at": "2025-01-11T02:36:51.732606866Z",
      "size": 38872431643,
      "digest": "e59b580dfce7ae2e97235344bd8fd4c1ace9c6aff683652ac0ea3b4c9f4865f1",
      "details": {
        "parent_model": "",
        "format": "gguf",
        "family": "llama",
        "families": [
          "llama"
        ],
        "parameter_size": "69B",
        "quantization_level": "Q4_0"
      }
    },
    {
      "name": "videoid-extractor:latest",
      "model": "videoid-extractor:latest",
      "modified_at": "2024-06-25T11:10:11.55597971Z",
      "size": 3826794283,
      "digest": "bd8a5c836da91f55ea1acd8f3a9235b8284506fa17119920c2f9cf80bb5c78d1",
      "details": {
        "parent_model": "",
        "format": "gguf",
        "family": "llama",
        "families": [
          "llama"
        ],
        "parameter_size": "6.7B",
        "quantization_level": "Q4_0"
      }
    },
    {
      "name": "business-idea2:latest",
      "model": "business-idea2:latest",
      "modified_at": "2024-06-25T10:05:07.678061961Z",
      "size": 3826794768,
      "digest": "47746885dad478c23daa83696c81f2b59ef46f6643613e55972359ebb528fc61",
      "details": {
        "parent_model": "",
        "format": "gguf",
        "family": "llama",
        "families": [
          "llama"
        ],
        "parameter_size": "6.7B",
        "quantization_level": "Q4_0"
      }
    },
    {
      "name": "business-idea:latest",
      "model": "business-idea:latest",
      "modified_at": "2024-06-25T10:04:12.177724819Z",
      "size": 3826794767,
      "digest": "bfcde65852a9846323760dda7fd3e8dd9424c7b4dcf9ca56e035a95d48116675",
      "details": {
        "parent_model": "",
        "format": "gguf",
        "family": "llama",
        "families": [
          "llama"
        ],
        "parameter_size": "6.7B",
        "quantization_level": "Q4_0"
      }
    },
    {
      "name": "super-mario:latest",
      "model": "super-mario:latest",
      "modified_at": "2024-06-25T09:06:52.232779024Z",
      "size": 3826793844,
      "digest": "2dd8ef2d0e148dc55e4942a78fe70624d1ba11af82bef2263596157d96ecdf38",
      "details": {
        "parent_model": "",
        "format": "gguf",
        "family": "llama",
        "families": [
          "llama"
        ],
        "parameter_size": "6.7B",
        "quantization_level": "Q4_0"
      }
    },
    {
      "name": "codellama:code",
      "model": "codellama:code",
      "modified_at": "2024-06-25T06:10:49.84016353Z",
      "size": 3825910440,
      "digest": "fc84f39375bcfe7612f7636a681ebb13d54eb4466e6ea6da07b5d1c37b49994d",
      "details": {
        "parent_model": "",
        "format": "gguf",
        "family": "llama",
        "families": null,
        "parameter_size": "7B",
        "quantization_level": "Q4_0"
      }
    }
  ]
}
```

* The server fails to start with the wrong param

```console
/opt/homebrew/bin/pnpm start

> @maiar-ai/maiar-starter@0.0.0 start /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/maiar-starter
> node dist/index.js

Starting agent...
[Express Plugin] Starting HTTP request listener
[Express Plugin] Express middleware configured
[Express Plugin] Server is running on localhost:3000
[2025-02-15 20:15:47.522 -0800] INFO: memory:sqlite: SQLite health check passed
    component: "memory:sqlite"
[2025-02-15 20:15:47.523 -0800] INFO: models: Initialized LLM service: ollama
    component: "models"
[2025-02-15 20:15:47.529 -0800] INFO: memory: Initialized memory service with provider: sqlite
    component: "memory"
[2025-02-15 20:15:47.531 -0800] INFO: memory:sqlite: Initialized SQLite memory storage
    component: "memory:sqlite"
[2025-02-15 20:15:47.531 -0800] INFO: runtime: Initialized runtime with plugins
    component: "runtime"
    plugins: [
      "plugin-express",
      "plugin-text",
      "plugin-time",
      "plugin-character",
      "plugin-search"
    ]
[2025-02-15 20:15:47.531 -0800] INFO: runtime: Starting evaluation loop
    component: "runtime"
[2025-02-15 20:15:47.552 -0800] ERROR: model:ollama: Ollama model 'llama2' health check failed: model not deployed
    component: "model:ollama"
[2025-02-15 20:15:47.552 -0800] ERROR: runtime: LLM Model failed to initialize
    component: "runtime"
/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047
      throw new Error(err.message);
            ^

Error: Model "llama2" not deployed in Ollama server
    at /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047:13
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

Node.js v23.5.0
 ELIFECYCLE  Command failed with exit code 1.

Process finished with exit code 1
```

## ✅ Happy path for Ollama health check

* The correct name of the model according to the server
* The parameter was the following:

```typescript
const runtime = createRuntime({
  model: new OllamaProvider({
    baseUrl: "http://localhost:11434",
    model: "codellama:70b"
  }),
```

```console
> @maiar-ai/maiar-starter@0.0.0 start /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/maiar-starter
> node dist/index.js

Starting agent...
[Express Plugin] Starting HTTP request listener
[Express Plugin] Express middleware configured
[Express Plugin] Server is running on localhost:3000
[2025-02-15 20:26:13.303 -0800] INFO: memory:sqlite: SQLite health check passed
    component: "memory:sqlite"
[2025-02-15 20:26:13.304 -0800] INFO: models: Initialized LLM service: ollama
    component: "models"
[2025-02-15 20:26:13.310 -0800] INFO: memory: Initialized memory service with provider: sqlite
    component: "memory"
[2025-02-15 20:26:13.312 -0800] INFO: memory:sqlite: Initialized SQLite memory storage
    component: "memory:sqlite"
[2025-02-15 20:26:13.312 -0800] INFO: runtime: Initialized runtime with plugins
    component: "runtime"
    plugins: [
      "plugin-express",
      "plugin-text",
      "plugin-time",
      "plugin-character",
      "plugin-search"
    ]
[2025-02-15 20:26:13.312 -0800] INFO: runtime: Starting evaluation loop
    component: "runtime"
[2025-02-15 20:26:13.332 -0800] INFO: model:ollama: Ollama model 'codellama:70b' health check passed
    component: "model:ollama"
```

# 💻 Custom Deepseek Model

* The healthcheck for this model is just checking on any of its model in Ollama server

> [!TIP]
> * Deepseek models are similar to Ollama's, but prefixed with "deepseek-`
>  * Similar model structure from Ollama, but customized with output parsing for reasoning tokens
> * The new log statement would show users this is a healthcheck error and they should follow the possible solutions
> ```
> Error: Deepseek Model "codellama:70b" must be prefixed with deepseek-
> ```
> * Or that the model doesn't exist
> ```
> [2025-02-15 21:18:29.952 -0800] ERROR: models: Deepseek model 'deepseek-r1' health check failed: model not deployed in ollama server
> ```
> * Also, the list of existing models is printed in the error
>```
> Error: Model "deepseek-rest" not deployed in Ollama server. Available models: deepseek-r1:latest, llama2:latest, codellama:70b, videoid-extractor:latest, business-idea2:latest, business-idea:latest, super-mario:latest, codellama:code
>```

* Here's the full logs

```console
[2025-02-15 21:15:36.206 -0800] INFO: models: Initialized LLM service: deepseek
    component: "models"
[2025-02-15 21:15:36.206 -0800] INFO: memory: Initialized memory service with provider: sqlite
    component: "memory"
[2025-02-15 21:15:36.210 -0800] INFO: memory:sqlite: Initialized SQLite memory storage
    component: "memory:sqlite"
[2025-02-15 21:15:36.211 -0800] ERROR: runtime: LLM Model failed to initialize
    component: "runtime"
[2025-02-15 21:15:36.211 -0800] INFO: runtime: Initialized runtime with plugins
    component: "runtime"
    plugins: [
      "plugin-express",
      "plugin-text",
      "plugin-time",
      "plugin-character",
      "plugin-search"
    ]
[2025-02-15 21:15:36.211 -0800] INFO: runtime: Starting evaluation loop
    component: "runtime"
/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047
      throw new Error(err.message);
            ^

Error: Model "codellama:70b" not deployed in Ollama server. Available models: deepseek-r1:latest, llama2:latest, codellama:70b, videoid-extractor:latest, business-idea2:latest, business-idea:latest, super-mario:latest, codellama:code
    at /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047:13
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

Node.js v23.5.0
 ELIFECYCLE  Command failed with exit code 1.

Process finished with exit code 1
```

* Then, here's the output for when the model doesn't exist

```console
[2025-02-15 21:35:47.666 -0800] INFO: runtime: Starting evaluation loop
    component: "runtime"
[2025-02-15 21:35:47.685 -0800] ERROR: models: Deepseek model 'deepseek-rest' health check failed: model not deployed in ollama server
    component: "models"
[2025-02-15 21:35:47.685 -0800] ERROR: runtime: LLM Model failed to initialize
    component: "runtime"
/Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047
      throw new Error(err.message);
            ^

Error: Model "deepseek-rest" not deployed in Ollama server. Available models: deepseek-r1:latest, llama2:latest, codellama:70b, videoid-extractor:latest, business-idea2:latest, business-idea:latest, super-mario:latest, codellama:code
    at /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/packages/core/dist/index.js:1047:13
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

Node.js v23.5.0
 ELIFECYCLE  Command failed with exit code 1.

Process finished with exit code 1
```

## 🐳 Pulling deepseek-r1:latest 

* Just pulling to test the server

```console
$ docker run --network host  -ti -v $(pwd):$(pwd) -w $(pwd) -v $HOME/.ollama:/root/.ollama ollama/ollama pull deepseek-r1
pulling manifest
pulling 96c415656d37...   1% ▕█
sooo damn slowwww
$ docker run --network host  -ti -v $(pwd):$(pwd) -w $(pwd) -v $HOME/.ollama:/root/.ollama ollama/ollama pull deepseek-r1
pulling manifest
pulling 96c415656d37...  11% ▕████████████                                                                                                  ▏ 513 MB/4.7 GB
```

## ✅ Happy Path 

* When any of the matching models exist

```console
/opt/homebrew/bin/pnpm start

> @maiar-ai/maiar-starter@0.0.0 prestart /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/maiar-starter
> tsc --project tsconfig.json


> @maiar-ai/maiar-starter@0.0.0 start /Users/marcellodesales/dev/github.com/marcellodesales/maiar-ai/maiar-starter
> node dist/index.js

Starting agent...
[Express Plugin] Starting HTTP request listener
[Express Plugin] Express middleware configured
[Express Plugin] Server is running on localhost:3000
[2025-02-15 21:28:40.218 -0800] INFO: memory:sqlite: SQLite health check passed
    component: "memory:sqlite"
[2025-02-15 21:28:40.219 -0800] INFO: models: Initialized LLM service: deepseek
    component: "models"
[2025-02-15 21:28:40.225 -0800] INFO: memory: Initialized memory service with provider: sqlite
    component: "memory"
[2025-02-15 21:28:40.227 -0800] INFO: memory:sqlite: Initialized SQLite memory storage
    component: "memory:sqlite"
[2025-02-15 21:28:40.227 -0800] INFO: runtime: Initialized runtime with plugins
    component: "runtime"
    plugins: [
      "plugin-express",
      "plugin-text",
      "plugin-time",
      "plugin-character",
      "plugin-search"
    ]
[2025-02-15 21:28:40.227 -0800] INFO: runtime: Starting evaluation loop
    component: "runtime"
[2025-02-15 21:28:40.244 -0800] INFO: models: Deepseek model 'deepseek-r1:latest' health check passed
    component: "models"
```