### PR TITLE
feat: plugin-x abstract more settings to plugin config

### DIFF
--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -14,6 +14,10 @@ config({
 
 import { createRuntime } from "@maiar-ai/core";
 
+// Import providers
+import { OpenAIProvider } from "@maiar-ai/model-openai";
+import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
+
 // Import all plugins
 import { PluginExpress } from "@maiar-ai/plugin-express";
 import { PluginTextGeneration } from "@maiar-ai/plugin-text";
@@ -21,8 +25,6 @@ import { PluginTime } from "@maiar-ai/plugin-time";
 import { PluginCharacter } from "@maiar-ai/plugin-character";
 import { PluginSearch } from "@maiar-ai/plugin-search";
 import { PluginX } from "@maiar-ai/plugin-x";
-import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
-import { OpenAIProvider } from "@maiar-ai/model-openai";
 
 import appRouter from "./app";
 // Create and start the agent
@@ -53,7 +55,9 @@ const runtime = createRuntime({
     new PluginX({
       username: process.env.X_USERNAME as string,
       password: process.env.X_PASSWORD as string,
-      email: process.env.X_EMAIL as string
+      email: process.env.X_EMAIL as string,
+      mentionsCheckIntervalMins: 10,
+      loginRetries: 3
     })
   ]
 });

--- a/packages/plugin-x/README.md
+++ b/packages/plugin-x/README.md
@@ -6,3 +6,41 @@ This package is part of the [Maiar](https://maiar.dev) ecosystem, designed to wo
 
 For detailed documentation, examples, and API reference, visit:
 https://maiar.dev/docs
+
+## Configuration
+
+The X plugin requires the following configuration:
+
+```typescript
+interface XPluginConfig {
+  username: string; // Your X (Twitter) username
+  password: string; // Your X (Twitter) account password
+  email: string; // Email associated with your X account
+  mentionsCheckIntervalMins?: number; // Optional: Interval to check for mentions (default: 5)
+  loginRetries?: number; // Optional: Number of login retry attempts (default: 3)
+}
+```
+
+### Required Configuration
+
+- `username`: Your X (Twitter) account username
+- `password`: Your X (Twitter) account password
+- `email`: Email address associated with your X account
+
+### Optional Configuration
+
+- `mentionsCheckIntervalMins`: How often to check for new mentions in minutes (default: 5)
+- `loginRetries`: Number of login retry attempts if initial login fails (default: 3)
+
+## Plugin Information
+
+### Actions
+
+- `post_tweet`: Post a new tweet (not a reply). Used when you want to post a new tweet that is not in response to another tweet.
+- `send_tweet`: Send a tweet as a reply to a specific tweet. This action requires a tweet ID from the context and is primarily used when processing mention events.
+
+### Triggers
+
+- `mentions`: Monitors and processes mentions of the configured X account. Automatically checks for new mentions at configured intervals and handles user interactions.
+
+For more detailed examples and advanced usage, visit our [documentation](https://maiar.dev/docs).

--- a/packages/plugin-x/src/plugin.ts
+++ b/packages/plugin-x/src/plugin.ts
@@ -16,6 +16,8 @@ export class PluginX extends PluginBase {
   private mentionsTimer?: ReturnType<typeof setInterval>;
   private scraper: Scraper;
   private initialized: Promise<void>;
+  private mentionsCheckIntervalMins: number;
+  private loginRetries: number;
 
   constructor(private config: XPluginConfig) {
     super({
@@ -23,6 +25,10 @@ export class PluginX extends PluginBase {
       name: "X",
       description: "Handles x requests for the Maiar agent"
     });
+
+    // Set default values for optional config parameters
+    this.mentionsCheckIntervalMins = this.config.mentionsCheckIntervalMins || 5;
+    this.loginRetries = this.config.loginRetries || 3;
 
     if (!this.config.username || !this.config.password || !this.config.email) {
       throw new Error(
@@ -144,7 +150,7 @@ export class PluginX extends PluginBase {
           await this.initialized;
 
           log.info("Starting mentions trigger");
-          const intervalMs = 1 * 60 * 1000; // 1 minute
+          const intervalMs = this.mentionsCheckIntervalMins * 60 * 1000;
 
           await this.checkMentions();
           this.mentionsTimer = setInterval(
@@ -159,7 +165,7 @@ export class PluginX extends PluginBase {
   }
 
   private async initializeTwitter(): Promise<void> {
-    const maxRetries = 3;
+    const maxRetries = this.loginRetries;
     let retries = maxRetries;
 
     while (retries > 0) {

--- a/packages/plugin-x/src/types.ts
+++ b/packages/plugin-x/src/types.ts
@@ -4,6 +4,8 @@ export interface XPluginConfig {
   username: string;
   password: string;
   email: string;
+  mentionsCheckIntervalMins?: number;
+  loginRetries?: number;
 }
 
 export interface XPlatformContext


### PR DESCRIPTION
## Description
Some simple configuration items have been abstracted up to the plugin config to give the plugin consumers some control over mentions polling and login behavior

## Related Issues
NA

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test
You can change the `checkMentions` polling rate. 

## Checklist

- [ ] Code follows project style guidelines
- [ ] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [ ] Ready for review 🚀
