### PR TITLE
chore(setup): 🔧 disable git commit header/subject/body/footer max length

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -58,7 +58,13 @@ const commitlintConfig: UserConfig = {
         "maiar-starter", // maiar-starter directory
         "website" // documentation website
       ]
-    ]
+    ],
+    "header-max-length": [0],
+    "subject-max-length": [0],
+    "body-max-length": [0],
+    "body-max-line-length": [0],
+    "footer-max-length": [0],
+    "footer-max-line-length": [0]
   }
 };
 


### PR DESCRIPTION
## Description

Disable git commit header/subject/body/footer max length in `commitlint` config

## Related Issues

Git commit messages blocked by a `commitlint` max length rule during pre-commit hooks for the header/subject/body/footer for chars exceeding 100 (`commitlint` default rule)

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

```sh
git commit --allow-empty  -m "chore: <subject longer than 100 chars>

<description longer than 100 chars>

<footer longer than 100 chars>"
```

```sh
git commit --allow-empty -m "test: 1234567890qwertyuiopasdfghjklzzxcvbnm1234567890qwertyuiopasdfghjklzzxcvbnm1234567890qwertyuiopasdfghjklzzxcvbnm

1234567890qwertyuiopasdfghjklzzxcvbnm 1234567890qwertyuiopasdfghjklzzxcvbnm 1234567890qwertyuiopasdfghjklzzxcvbnm

1234567890qwertyuiopasdfghjklzzxcvbnm 1234567890qwertyuiopasdfghjklzzxcvbnm 1234567890qwertyuiopasdfghjklzzxcvbnm"

> @maiar-ai/monorepo@ commitlint /Users/knguyen/personal/kevdev/maiar-ai
> commitlint --edit ".git/COMMIT_EDITMSG"

[config/commitlint edd6eab] test: 1234567890qwertyuiopasdfghjklzzxcvbnm1234567890qwertyuiopasdfghjklzzxcvbnm1234567890qwertyuiopasdfghjklzzxcvbnm
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
