### PR TITLE
cd(bug): 🐛⚙️ install maiar-intern gh app in package-release job for git permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,10 +81,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.package-release-prep.outputs.source-code == 'true' && needs.commit-analyzer.outputs.releasable == 'true' }}
     steps:
+      - name: 🔑 Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 🔧 Configure Git
         run: |


### PR DESCRIPTION
## Description

Install `maiar-intern` GH App on the package-release job that has permissions to commit/push to github

## Related Issues

package-release job could not commit/push to github due to permission error - https://github.com/UraniumCorporation/maiar-ai/actions/runs/13365650585/job/37322791960

<img width="1297" alt="Screenshot 2025-02-17 at 7 43 10 PM" src="https://github.com/user-attachments/assets/b559f02c-a3d3-400b-ad9b-5c79d58b4003" />

## Changes Made

- [x] Feature added
- [x] Bug fixed
- [x] Code refactored
- [x] Documentation updated

## How to Test

Workflow Run demonstrating this is working - https://github.com/k3v-d3v/maiar-ai/actions/runs/13344782861/job/37273898721
Workflow File for the Workflow Run - https://github.com/k3v-d3v/maiar-ai/actions/runs/13344782861/workflow

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
