### PR TITLE
cd(fix): 🐛🔧 add lerna version flag to ensure a release train

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,11 +187,10 @@ jobs:
           git config --global user.email "maiar-intern@users.noreply.github.com"
 
       - name: 🔎📦 Commit Changes on API Doc Changes
-        continue-on-error: true
         run: |
           if git diff --quiet website/api; then
-            echo "No API documentation changes detected. Failing the job."
-            exit 1
+            echo "No API documentation changes detected. Skipping commit..."
+            exit 0
           fi
 
           echo "API documentation has changed from relevant code changes in packages/**/src/*.ts files"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: 🔖 (Tag + Release) Packages to Github Repo
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm lerna version --yes --no-private --conventional-commits --create-release github --loglevel silly
+        run: pnpm lerna version --yes --no-private --conventional-commits --force-publish --create-release github --loglevel silly
 
       - name: 🚀 Publish Packages to NPM
         run: |


### PR DESCRIPTION
## Description

🐛🔧 Add lerna version flag `--force-publish` to make it so all packages (whether it has changes or not) will bump the SemVer version determined by the conventional commit within the merge

📝 Miscellaneous:
- 🔧 No API doc changes should not error out and gracefully exit

## Related Issues

In the package release for v0.6.1, the pipeline determined a patch release was needed but did not bump other packages and only the one that had file changes, however, we need them all to bump as a release train to ensure compatibility for core and official supported plugins

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

`--force-publish` flag description - https://github.com/lerna/lerna/blob/main/libs/commands/version/README.md#--force-publish

```
When run with this flag, lerna version will force publish the specified packages (comma-separated) or all packages using *.
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
