### PR TITLE
bug: cross platform hot reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ logs
 # macOS
 .DS_Store
 **/.DS_Store
+
+# PID
+.pid

--- a/README.md
+++ b/README.md
@@ -181,23 +181,22 @@ This command watches for changes in the core packages (`packages/**/*.ts`) and a
 
 1. Cleans any previous build state
 2. Builds all core packages
-3. Creates a `.build-complete` marker file to indicate the core packages build is finished as a state file to communicate with the starter project
+3. Updates the `.build-complete` marker file with current timestamp to indicate the core packages build is finished as a state file to communicate with the development project
 4. Watches for changes and repeats the process
 
-**Terminal 2 - Starter Project:**
+**Terminal 2 - Development Project:**
 
 ```bash
 # From the root of the repository
-cd maiar-starter
+cd maiar-starter # or your own development project
 pnpm dev
 ```
 
 This command runs the starter project in development mode. It:
 
-1. Watches for changes in both the starter project's source files and core package builds
-2. Waits for core packages to finish building (using the `.build-complete` marker)
-3. Rebuilds the starter project
-4. Restarts the application automatically
+1. Watches for changes in both the starter project's source files and the core packages through the `.build-complete` marker file
+2. Rebuilds the starter project
+3. Restarts the application automatically and handles exiting gracefully so orphaned processes are cleaned up
 
 This setup ensures that changes to either the core packages or the starter project are automatically rebuilt and reflected in your running application, providing a seamless development experience.
 

--- a/maiar-starter/package.json
+++ b/maiar-starter/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "chokidar '../.build-complete' 'src/**/*.ts' --initial --verbose -c 'pnpm run wait-for-build && pnpm build && pnpm run restart'",
-    "wait-for-build": "[ -f ../.build-complete ] && printf \"\\e[32m⚡🟢 Core already built!\\e[0m\\n\" || (printf \"\\e[32m♻️🟢 Re-building core...\\e[0m\\n\"; while [ ! -f ../.build-complete ]; do sleep 0.1; done; printf \"\\e[32m✅🟢 Core build complete!\\e[0m\\n\")",
-    "restart": "node -e \"const fs=require('fs');const {spawn}=require('child_process');const pid=fs.existsSync('.pid')?fs.readFileSync('.pid','utf-8'):null;if(pid){try{process.kill(pid,'SIGTERM');console.log('Terminated previous process:',pid)}catch(e){console.log('No previous process found')}}setTimeout(()=>{const proc=spawn('node',['dist/index.js'],{stdio:'inherit',detached:true});proc.on('spawn',()=>console.log('Started new process:',proc.pid));proc.on('error',(err)=>console.error('Failed to start process:',err));fs.writeFileSync('.pid',String(proc.pid));proc.unref()},1000)\"",
+    "dev": "chokidar '../.build-complete' 'src/**/*.ts' --initial --verbose -c 'pnpm build && pnpm run restart'",
+    "restart": "node ../restart.js",
     "build": "tsc --project tsconfig.json",
     "start": "node dist/index.js"
   },

--- a/maiar-starter/package.json
+++ b/maiar-starter/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "chokidar 'src/**/*.ts' '../.build-complete' -c 'pnpm run wait-for-build && pnpm build:starter && pkill -f \"node dist/index.js\"; pnpm start' --initial --verbose",
+    "dev": "chokidar '../.build-complete' 'src/**/*.ts' --initial --verbose -c 'pnpm run wait-for-build && pnpm build && pnpm run restart'",
     "wait-for-build": "[ -f ../.build-complete ] && printf \"\\e[32m⚡🟢 Core already built!\\e[0m\\n\" || (printf \"\\e[32m♻️🟢 Re-building core...\\e[0m\\n\"; while [ ! -f ../.build-complete ]; do sleep 0.1; done; printf \"\\e[32m✅🟢 Core build complete!\\e[0m\\n\")",
-    "build:starter": "tsc --project tsconfig.json",
+    "restart": "node -e \"const fs=require('fs');const {spawn}=require('child_process');const pid=fs.existsSync('.pid')?fs.readFileSync('.pid','utf-8'):null;if(pid){try{process.kill(pid,'SIGTERM');console.log('Terminated previous process:',pid)}catch(e){console.log('No previous process found')}}setTimeout(()=>{const proc=spawn('node',['dist/index.js'],{stdio:'inherit',detached:true});proc.on('spawn',()=>console.log('Started new process:',proc.pid));proc.on('error',(err)=>console.error('Failed to start process:',err));fs.writeFileSync('.pid',String(proc.pid));proc.unref()},1000)\"",
+    "build": "tsc --project tsconfig.json",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "type": "module",
   "scripts": {
     "prepare": "husky",
-    "dev": "rm -f .build-complete && pnpm run build && touch .build-complete && chokidar 'packages/**/*.ts' --ignore 'packages/**/dist/**' -c 'rm -f .build-complete && pnpm run build && touch .build-complete'",
+    "dev": "rm -f .build-complete && pnpm run build && date +%s > .build-complete && chokidar 'packages/**/*.ts' --ignore 'packages/**/dist/**' -c 'pnpm run build && date +%s > .build-complete'",
     "build": "turbo run build --filter=./packages/*",
     "build:website": "turbo run build:website --filter=./website",
     "build:starter": "turbo run build:starter --filter=./maiar-starter",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "type": "module",
   "scripts": {
     "prepare": "husky",
-    "dev": "rm -f .build-complete && pnpm run build && date +%s > .build-complete && chokidar 'packages/**/*.ts' --ignore 'packages/**/dist/**' -c 'pnpm run build && date +%s > .build-complete'",
+    "dev": "pnpm run build && date +%s > .build-complete && chokidar 'packages/**/*.ts' --ignore 'packages/**/dist/**' -c 'pnpm run build && date +%s > .build-complete'",
     "build": "turbo run build --filter=./packages/*",
     "build:website": "turbo run build:website --filter=./website",
     "build:starter": "turbo run build:starter --filter=./maiar-starter",

--- a/restart.js
+++ b/restart.js
@@ -19,7 +19,6 @@ const terminateExistingProcess = () => {
         );
       }
     }
-    fs.unlinkSync(pidFile);
   }
 };
 
@@ -43,9 +42,6 @@ const startChildProcess = () => {
 
   child.on("exit", (code, signal) => {
     console.log(`Child process exited with code ${code} and signal ${signal}`);
-    if (fs.existsSync(pidFile)) {
-      fs.unlinkSync(pidFile);
-    }
   });
 
   return child;

--- a/restart.js
+++ b/restart.js
@@ -1,0 +1,88 @@
+import fs from "fs";
+import { spawn } from "child_process";
+
+const pidFile = ".pid";
+
+/**
+ * Function to terminate an existing child process based on PID file
+ */
+const terminateExistingProcess = () => {
+  if (fs.existsSync(pidFile)) {
+    const pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
+    if (!isNaN(pid)) {
+      try {
+        process.kill(pid, "SIGTERM");
+        console.log(`Terminated previous process with PID: ${pid}`);
+      } catch (e) {
+        console.log(
+          `No previous process found or unable to terminate PID ${pid}: ${e.message}`
+        );
+      }
+    }
+    fs.unlinkSync(pidFile);
+  }
+};
+
+/**
+ * Function to start the new child process
+ * @returns {ChildProcess} - The spawned child process
+ */
+const startChildProcess = () => {
+  const child = spawn("node", ["dist/index.js"], {
+    stdio: "inherit"
+  });
+
+  child.on("spawn", () => {
+    console.log(`Started new process with PID: ${child.pid}`);
+    fs.writeFileSync(pidFile, String(child.pid));
+  });
+
+  child.on("error", (err) => {
+    console.error("Failed to start child process:", err);
+  });
+
+  child.on("exit", (code, signal) => {
+    console.log(`Child process exited with code ${code} and signal ${signal}`);
+    if (fs.existsSync(pidFile)) {
+      fs.unlinkSync(pidFile);
+    }
+  });
+
+  return child;
+};
+
+// Main execution flow
+const main = async () => {
+  // Terminate any existing process from PID file
+  terminateExistingProcess();
+
+  // Start the new child process
+  const childProcess = startChildProcess();
+
+  // Handle termination signals
+  const handleExit = () => {
+    if (childProcess && childProcess.pid) {
+      console.log(`Terminating child process with PID: ${childProcess.pid}`);
+      try {
+        process.kill(childProcess.pid, "SIGTERM");
+        console.log("Child process terminated successfully.");
+      } catch (err) {
+        console.error("Error terminating child process:", err.message);
+      }
+    }
+    process.exit();
+  };
+
+  // Handle termination signals
+  process.on("SIGTERM", handleExit);
+  process.on("SIGINT", handleExit);
+  process.on("SIGHUP", handleExit);
+  process.on("SIGQUIT", handleExit);
+  process.on("SIGBREAK", handleExit);
+};
+
+// Execute the main function
+main().catch((err) => {
+  console.error("Error in restart script:", err);
+  process.exit(1);
+});

--- a/website/docs/contributing-guide.md
+++ b/website/docs/contributing-guide.md
@@ -27,11 +27,10 @@ pnpm install
 
 3. Start the development environment. You'll need two terminal windows:
 
-### Terminal 1 - Core Packages
-
-**From the root of the repository**
+**Terminal 1 - Core Packages:**
 
 ```bash
+# From the root of the repository
 pnpm dev
 ```
 
@@ -39,27 +38,25 @@ This command watches for changes in the core packages (`packages/**/*.ts`) and a
 
 1. Cleans any previous build state
 2. Builds all core packages
-3. Creates a `.build-complete` marker file to indicate the core packages build is finished as a state file to communicate with the starter project
+3. Updates the `.build-complete` marker file with current timestamp to indicate the core packages build is finished as a state file to communicate with the development project
 4. Watches for changes and repeats the process
 
-### Terminal 2 - Starter Project
-
-**From the root of the repository**
+**Terminal 2 - Development Project:**
 
 ```bash
-cd maiar-starter
+# From the root of the repository
+cd maiar-starter # or your own development project
 pnpm dev
 ```
 
 This command runs the starter project in development mode. It:
 
-1. Watches for changes in both the starter project's source files and core package builds
-2. Waits for core packages to finish building (using the `.build-complete` marker)
-3. Rebuilds the starter project
-4. Restarts the application automatically
+1. Watches for changes in both the starter project's source files and the core packages through the `.build-complete` marker file
+2. Rebuilds the starter project
+3. Restarts the application automatically and handles exiting gracefully so orphaned processes are cleaned up
 
 This setup ensures that changes to either the core packages or the starter project are automatically rebuilt and reflected in your running application, providing a seamless development experience.
 
-> **_NOTE_**
+> [!NOTE]
 >
 > The `maiar-starter` project serves as a reference implementation demonstrating how to develop against the core Maiar packages. You can apply this same development setup to any project that depends on Maiar packages - simply mirror the dev script configuration and `.build-complete` marker file handling shown in the starter project's package.json. The key focus of this repository is the core packages in `packages/*`, with `maiar-starter` serving as an example consumer.

--- a/website/docs/contributing-guide.md
+++ b/website/docs/contributing-guide.md
@@ -27,10 +27,11 @@ pnpm install
 
 3. Start the development environment. You'll need two terminal windows:
 
-**Terminal 1 - Core Packages:**
+### Terminal 1 - Core Packages
+
+**From the root of the repository**
 
 ```bash
-# From the root of the repository
 pnpm dev
 ```
 
@@ -38,14 +39,15 @@ This command watches for changes in the core packages (`packages/**/*.ts`) and a
 
 1. Cleans any previous build state
 2. Builds all core packages
-3. Updates the `.build-complete` marker file with current timestamp to indicate the core packages build is finished as a state file to communicate with the development project
+3. Updates the `.build-complete` marker file with current timestamp to indicate the core packages build is finished as a state file to communicate with the starter project
 4. Watches for changes and repeats the process
 
-**Terminal 2 - Development Project:**
+### Terminal 2 - Starter Project
+
+**From the root of the repository**
 
 ```bash
-# From the root of the repository
-cd maiar-starter # or your own development project
+cd maiar-starter
 pnpm dev
 ```
 
@@ -57,6 +59,6 @@ This command runs the starter project in development mode. It:
 
 This setup ensures that changes to either the core packages or the starter project are automatically rebuilt and reflected in your running application, providing a seamless development experience.
 
-> [!NOTE]
+> **_NOTE_**
 >
 > The `maiar-starter` project serves as a reference implementation demonstrating how to develop against the core Maiar packages. You can apply this same development setup to any project that depends on Maiar packages - simply mirror the dev script configuration and `.build-complete` marker file handling shown in the starter project's package.json. The key focus of this repository is the core packages in `packages/*`, with `maiar-starter` serving as an example consumer.


### PR DESCRIPTION
## Description

Currently hot reload fails on all Debian based systems as the `pkill` process is handled differently between operating systems. There is also an issue that prevents projects from rebuilding when the top level packages are rebuilt. This issue is caused by `chokidar` not watching files after they are deleted.

- Do not remove the `.build-complete` file when rebuilding core packages and plugins, instead modify it with the current timestamp
- Instead of using `pkill -f "node dist/index.js"` we save the PID of the process in a `.pid` file at the project level, and when we call a node process to send a SIGTERM signal to that PID, start the project again and store the new PID
- Restart script handles SIGINT signals so that no orphaned processes are left running if the user exits `pnpm dev` with `Ctrl+C`

## Related Issues

Closes #21 

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

- `pnpm dev` in the top level directory
- `cd maiar-starter && pnpm dev`
- Make changes in a plugin and save, watch the reload triggered by the top level `pnpm dev` script then verify that the `maiar-starter` project was rebuilt
- `Ctrl+C` in the `maiar-starter` terminal then `rm .pid` and run `pnpm dev` again, this should launch without issue as the SIGINT signal is being handled properly

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
