### PR TITLE
feat: make plugin-telegram composable by accepting bot handlers

### DIFF
--- a/maiar-starter/package.json
+++ b/maiar-starter/package.json
@@ -16,16 +16,18 @@
     "@maiar-ai/plugin-character": "workspace:*",
     "@maiar-ai/plugin-express": "workspace:*",
     "@maiar-ai/plugin-search": "workspace:*",
+    "@maiar-ai/plugin-telegram": "workspace:*",
     "@maiar-ai/plugin-text": "workspace:*",
     "@maiar-ai/plugin-time": "workspace:*",
     "@maiar-ai/plugin-x": "workspace:*",
     "@maiar-ai/plugin-terminal": "workspace:*",
     "dotenv": "16.4.7",
-    "express": "4.21.2"
+    "express": "4.21.2",
+    "telegraf": "4.16.3"
   },
   "devDependencies": {
-    "chokidar-cli": "3.0.0",
     "@types/express": "5.0.0",
+    "chokidar-cli": "3.0.0",
     "dotenv-cli": "8.0.0",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/maiar-starter/src/bot.ts
+++ b/maiar-starter/src/bot.ts
@@ -4,74 +4,72 @@ import {
   TelegramMessage,
   TelegramPlatformContext
 } from "@maiar-ai/plugin-telegram";
-import { Context } from "telegraf";
-import { UpdateType } from "telegraf/typings/telegram-types";
+import { Composer, Context } from "telegraf";
+
+const composer = new Composer();
 
 const log = createLogger("plugin-telegram");
-const telegramConfig = {
-  filter: "message" as UpdateType,
-  handler: async (ctx: Context) => {
-    try {
-      if (!ctx.message || (ctx.message && !("text" in ctx.message))) return;
-      if (!("plugin" in ctx)) return;
+composer.on("message", async (ctx: Context) => {
+  try {
+    if (!ctx.message || (ctx.message && !("text" in ctx.message))) return;
+    if (!("plugin" in ctx)) return;
 
-      const message: TelegramMessage = {
-        chatId: ctx.message.chat.id,
-        text: ctx.message.text,
-        username: ctx.message.from?.username
-      };
+    const message: TelegramMessage = {
+      chatId: ctx.message.chat.id,
+      text: ctx.message.text,
+      username: ctx.message.from?.username
+    };
 
-      const plugin = ctx.plugin as PluginTelegram;
-      const pluginId = plugin.id;
-      const userContext: UserInputContext = {
-        id: `${pluginId}-${Date.now()}`,
-        pluginId: pluginId,
-        type: "user_input",
-        action: "receiveMessage",
-        content: message.text,
-        timestamp: Date.now(),
-        rawMessage: message.text,
-        user: message.username || "unknown",
-        messageHistory: [
-          {
-            role: "user",
-            content: message.text,
-            timestamp: Date.now()
-          }
-        ],
-        helpfulInstruction: `Message from Telegram user ${message.username || "unknown"}`
-      };
-
-      const platformContext: TelegramPlatformContext = {
-        platform: pluginId,
-        responseHandler: async (response: unknown) => {
-          await ctx.reply(String(response));
-        },
-        metadata: {
-          chatId: message.chatId
+    const plugin = ctx.plugin as PluginTelegram;
+    const pluginId = plugin.id;
+    const userContext: UserInputContext = {
+      id: `${pluginId}-${Date.now()}`,
+      pluginId: pluginId,
+      type: "user_input",
+      action: "receiveMessage",
+      content: message.text,
+      timestamp: Date.now(),
+      rawMessage: message.text,
+      user: message.username || "unknown",
+      messageHistory: [
+        {
+          role: "user",
+          content: message.text,
+          timestamp: Date.now()
         }
-      };
+      ],
+      helpfulInstruction: `Message from Telegram user ${message.username || "unknown"}`
+    };
 
-      try {
-        await plugin.runtime.createEvent(userContext, platformContext);
-        log.debug("Successfully queued Telegram message for processing");
-      } catch (error) {
-        log.error("Failed to queue Telegram message", {
-          error: error instanceof Error ? error.message : String(error),
-          user: message.username,
-          chatId: message.chatId
-        });
+    const platformContext: TelegramPlatformContext = {
+      platform: pluginId,
+      responseHandler: async (response: unknown) => {
+        await ctx.reply(String(response));
+      },
+      metadata: {
+        chatId: message.chatId
       }
+    };
+
+    try {
+      await plugin.runtime.createEvent(userContext, platformContext);
+      log.debug("Successfully queued Telegram message for processing");
     } catch (error) {
-      log.error("Error processing Telegram message", {
+      log.error("Failed to queue Telegram message", {
         error: error instanceof Error ? error.message : String(error),
-        ctx: {
-          chatId: ctx.message?.chat.id,
-          username: ctx.message?.from?.username
-        }
+        user: message.username,
+        chatId: message.chatId
       });
     }
+  } catch (error) {
+    log.error("Error processing Telegram message", {
+      error: error instanceof Error ? error.message : String(error),
+      ctx: {
+        chatId: ctx.message?.chat.id,
+        username: ctx.message?.from?.username
+      }
+    });
   }
-};
+});
 
-export { telegramConfig };
+export default composer;

--- a/maiar-starter/src/bot.ts
+++ b/maiar-starter/src/bot.ts
@@ -5,10 +5,11 @@ import {
   TelegramPlatformContext
 } from "@maiar-ai/plugin-telegram";
 import { Context } from "telegraf";
+import { UpdateType } from "telegraf/typings/telegram-types";
 
 const log = createLogger("plugin-telegram");
 const telegramConfig = {
-  filter: "message",
+  filter: "message" as UpdateType,
   handler: async (ctx: Context) => {
     try {
       if (!ctx.message || (ctx.message && !("text" in ctx.message))) return;

--- a/maiar-starter/src/bot.ts
+++ b/maiar-starter/src/bot.ts
@@ -1,0 +1,76 @@
+import { createLogger, UserInputContext } from "@maiar-ai/core";
+import {
+  PluginTelegram,
+  TelegramMessage,
+  TelegramPlatformContext
+} from "@maiar-ai/plugin-telegram";
+import { Context } from "telegraf";
+
+const log = createLogger("plugin-telegram");
+const telegramConfig = {
+  filter: "message",
+  handler: async (ctx: Context) => {
+    try {
+      if (!ctx.message || (ctx.message && !("text" in ctx.message))) return;
+      if (!("plugin" in ctx)) return;
+
+      const message: TelegramMessage = {
+        chatId: ctx.message.chat.id,
+        text: ctx.message.text,
+        username: ctx.message.from?.username
+      };
+
+      const plugin = ctx.plugin as PluginTelegram;
+      const pluginId = plugin.id;
+      const userContext: UserInputContext = {
+        id: `${pluginId}-${Date.now()}`,
+        pluginId: pluginId,
+        type: "user_input",
+        action: "receiveMessage",
+        content: message.text,
+        timestamp: Date.now(),
+        rawMessage: message.text,
+        user: message.username || "unknown",
+        messageHistory: [
+          {
+            role: "user",
+            content: message.text,
+            timestamp: Date.now()
+          }
+        ],
+        helpfulInstruction: `Message from Telegram user ${message.username || "unknown"}`
+      };
+
+      const platformContext: TelegramPlatformContext = {
+        platform: pluginId,
+        responseHandler: async (response: unknown) => {
+          await ctx.reply(String(response));
+        },
+        metadata: {
+          chatId: message.chatId
+        }
+      };
+
+      try {
+        await plugin.runtime.createEvent(userContext, platformContext);
+        log.debug("Successfully queued Telegram message for processing");
+      } catch (error) {
+        log.error("Failed to queue Telegram message", {
+          error: error instanceof Error ? error.message : String(error),
+          user: message.username,
+          chatId: message.chatId
+        });
+      }
+    } catch (error) {
+      log.error("Error processing Telegram message", {
+        error: error instanceof Error ? error.message : String(error),
+        ctx: {
+          chatId: ctx.message?.chat.id,
+          username: ctx.message?.from?.username
+        }
+      });
+    }
+  }
+};
+
+export { telegramConfig };

--- a/maiar-starter/src/bot.ts
+++ b/maiar-starter/src/bot.ts
@@ -9,6 +9,11 @@ import { Composer, Context } from "telegraf";
 const composer = new Composer();
 
 const log = createLogger("plugin-telegram");
+
+composer.command("do_action", async (ctx) => {
+  return await ctx.reply("Did some action.");
+});
+
 composer.on("message", async (ctx: Context) => {
   try {
     if (!ctx.message || (ctx.message && !("text" in ctx.message))) return;
@@ -20,10 +25,13 @@ composer.on("message", async (ctx: Context) => {
       username: ctx.message.from?.username
     };
 
+    // telegram id
+    // twitter id
+    // call internal loading => scoped to teh bot.
     const plugin = ctx.plugin as PluginTelegram;
     const pluginId = plugin.id;
     const userContext: UserInputContext = {
-      id: `${pluginId}-${Date.now()}`,
+      id: `${pluginId}-${ctx.message.message_id}`,
       pluginId: pluginId,
       type: "user_input",
       action: "receiveMessage",
@@ -44,7 +52,7 @@ composer.on("message", async (ctx: Context) => {
     const platformContext: TelegramPlatformContext = {
       platform: pluginId,
       responseHandler: async (response: unknown) => {
-        await ctx.reply(String(response));
+        await ctx.reply(String(response), { parse_mode: "HTML" });
       },
       metadata: {
         chatId: message.chatId

--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -15,18 +15,21 @@ config({
 import { createRuntime } from "@maiar-ai/core";
 
 // Import providers
-import { OpenAIProvider } from "@maiar-ai/model-openai";
 import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
+import { OpenAIProvider } from "@maiar-ai/model-openai";
 
 // Import all plugins
+import { PluginCharacter } from "@maiar-ai/plugin-character";
 import { PluginExpress } from "@maiar-ai/plugin-express";
+import { PluginSearch } from "@maiar-ai/plugin-search";
+import { PluginTelegram } from "@maiar-ai/plugin-telegram";
+import { PluginTerminal } from "@maiar-ai/plugin-terminal";
 import { PluginTextGeneration } from "@maiar-ai/plugin-text";
 import { PluginTime } from "@maiar-ai/plugin-time";
-import { PluginCharacter } from "@maiar-ai/plugin-character";
-import { PluginSearch } from "@maiar-ai/plugin-search";
 import { PluginX } from "@maiar-ai/plugin-x";
-import { PluginTerminal } from "@maiar-ai/plugin-terminal";
 import appRouter from "./app";
+import { telegramConfig } from "./bot";
+
 // Create and start the agent
 const runtime = createRuntime({
   model: new OpenAIProvider({
@@ -62,6 +65,10 @@ const runtime = createRuntime({
     new PluginTerminal({
       user: "test",
       agentName: "maiar-starter"
+    }),
+    new PluginTelegram({
+      token: process.env.TELEGRAM_BOT_TOKEN as string,
+      handlers: [telegramConfig]
     })
   ]
 });

--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -28,7 +28,7 @@ import { PluginTextGeneration } from "@maiar-ai/plugin-text";
 import { PluginTime } from "@maiar-ai/plugin-time";
 import { PluginX } from "@maiar-ai/plugin-x";
 import appRouter from "./app";
-import { telegramConfig } from "./bot";
+import composer from "./bot";
 
 // Create and start the agent
 const runtime = createRuntime({
@@ -68,7 +68,7 @@ const runtime = createRuntime({
     }),
     new PluginTelegram({
       token: process.env.TELEGRAM_BOT_TOKEN as string,
-      handlers: [telegramConfig]
+      composer
     })
   ]
 });

--- a/packages/plugin-telegram/README.md
+++ b/packages/plugin-telegram/README.md
@@ -17,7 +17,7 @@ interface TelegramPluginConfig {
   composer: Composer<TelegramContext>; // Handlers to register
   // Optional configuration
   pollingTimeout?: number; // Polling timeout in seconds
-  dropPendingUpdates?: boolean; // Whether to drop pending updates on start
+  dropPendingUpdates?: boolean; // Whether pending updates are dropped on start/restart
 }
 ```
 

--- a/packages/plugin-telegram/README.md
+++ b/packages/plugin-telegram/README.md
@@ -9,7 +9,7 @@ https://maiar.dev/docs
 
 ## Configuration
 
-The X plugin requires the following configuration:
+The Telegram plugin requires the following configuration:
 
 ```typescript
 interface TelegramPluginConfig {

--- a/packages/plugin-telegram/README.md
+++ b/packages/plugin-telegram/README.md
@@ -6,3 +6,35 @@ This package is part of the [Maiar](https://maiar.dev) ecosystem, designed to wo
 
 For detailed documentation, examples, and API reference, visit:
 https://maiar.dev/docs
+
+## Configuration
+
+The X plugin requires the following configuration:
+
+```typescript
+interface TelegramPluginConfig {
+  token: string; // Telegram bot token
+  composer: Composer<TelegramContext>; // Handlers to register
+  // Optional configuration
+  pollingTimeout?: number; // Polling timeout in seconds
+  dropPendingUpdates?: boolean; // Whether to drop pending updates on start
+}
+```
+
+### Required Configuration
+
+- `token`: Your telegram bot token issued by BotFather
+- `composer`: A telegraf composer middleware
+
+### Optional Configuration
+
+- `pollingTimeout`: How often the bot will check for updates (default: 30)
+- `dropPendingUpdates`: Whether or not the bot will drop pending updates (default: false)
+
+## Plugin Information
+
+### Actions
+
+- `send_response`: Send a response to a telegram chat using the `responseHandler` provided on `context.platformContext.responseHandler`
+
+For more detailed examples and advanced usage, visit our [documentation](https://maiar.dev/docs).

--- a/packages/plugin-telegram/package.json
+++ b/packages/plugin-telegram/package.json
@@ -51,6 +51,7 @@
     "zod": "3.24.1"
   },
   "devDependencies": {
+    "chokidar-cli": "3.0.0",
     "@types/node": "22.13.1",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/packages/plugin-telegram/package.json
+++ b/packages/plugin-telegram/package.json
@@ -51,7 +51,6 @@
     "zod": "3.24.1"
   },
   "devDependencies": {
-    "chokidar-cli": "3.0.0",
     "@types/node": "22.13.1",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/packages/plugin-telegram/src/plugin.ts
+++ b/packages/plugin-telegram/src/plugin.ts
@@ -91,9 +91,8 @@ export class PluginTelegram extends PluginBase {
       return await next();
     });
 
-    for (const { filter, handler } of this.config.handlers) {
-      this.bot.on(filter, handler);
-    }
+    this.bot.use(this.config.composer);
+
     // Log all bot errors
     this.bot.catch((error) => {
       log.error("Bot error", {

--- a/packages/plugin-telegram/src/plugin.ts
+++ b/packages/plugin-telegram/src/plugin.ts
@@ -17,14 +17,6 @@ import { generateResponseTemplate } from "./templates";
 
 const log = createLogger("plugin:telegram");
 
-export interface TelegramPlatformContext {
-  platform: string;
-  responseHandler?: (response: unknown) => void;
-  metadata?: {
-    chatId: number;
-  };
-}
-
 export class PluginTelegram extends PluginBase {
   private bot: Telegraf<TelegramContext>;
 

--- a/packages/plugin-telegram/src/types.ts
+++ b/packages/plugin-telegram/src/types.ts
@@ -2,13 +2,20 @@ import { Composer, Context } from "telegraf";
 import { z } from "zod";
 import { PluginTelegram } from "./plugin";
 
+export interface TelegramPlatformContext {
+  platform: string;
+  responseHandler?: (response: unknown) => void;
+  metadata?: {
+    chatId: number;
+  };
+}
+
 export interface TelegramContext extends Context {
   plugin?: PluginTelegram;
 }
 
 export interface TelegramPluginConfig {
-  token?: string; // It's optional so we can load from the environment, but we check it in the constructor to make sure it's set
-
+  token: string; // Telegram bot token
   composer: Composer<TelegramContext>; // Handlers to register
   // Optional configuration
   pollingTimeout?: number; // Polling timeout in seconds

--- a/packages/plugin-telegram/src/types.ts
+++ b/packages/plugin-telegram/src/types.ts
@@ -1,11 +1,10 @@
 import { Context } from "telegraf";
 import { z } from "zod";
 import { PluginTelegram } from "./plugin";
-import { Guard } from "telegraf/typings/core/helpers/util";
-import { Update } from "telegraf/typings/core/types/typegram";
+import { UpdateType } from "telegraf/typings/telegram-types";
 
 interface TelegramHandler {
-  filter: Guard<Update>;
+  filter: UpdateType;
   handler: (ctx: Context, next?: () => Promise<void>) => Promise<void>;
 }
 

--- a/packages/plugin-telegram/src/types.ts
+++ b/packages/plugin-telegram/src/types.ts
@@ -1,17 +1,15 @@
-import { Context } from "telegraf";
+import { Composer, Context } from "telegraf";
 import { z } from "zod";
 import { PluginTelegram } from "./plugin";
-import { UpdateType } from "telegraf/typings/telegram-types";
 
-interface TelegramHandler {
-  filter: UpdateType;
-  handler: (ctx: Context, next?: () => Promise<void>) => Promise<void>;
+export interface TelegramContext extends Context {
+  plugin?: PluginTelegram;
 }
 
 export interface TelegramPluginConfig {
   token?: string; // It's optional so we can load from the environment, but we check it in the constructor to make sure it's set
 
-  handlers: TelegramHandler[]; // Handlers to register
+  composer: Composer<TelegramContext>; // Handlers to register
   // Optional configuration
   pollingTimeout?: number; // Polling timeout in seconds
   dropPendingUpdates?: boolean; // Whether to drop pending updates on start
@@ -21,10 +19,6 @@ export interface TelegramMessage {
   chatId: number;
   text: string;
   username?: string;
-}
-
-export interface TelegramContext extends Context {
-  plugin?: PluginTelegram;
 }
 
 export const TelegramResponseSchema = z.object({

--- a/packages/plugin-telegram/src/types.ts
+++ b/packages/plugin-telegram/src/types.ts
@@ -1,8 +1,18 @@
 import { Context } from "telegraf";
 import { z } from "zod";
+import { PluginTelegram } from "./plugin";
+import { Guard } from "telegraf/typings/core/helpers/util";
+import { Update } from "telegraf/typings/core/types/typegram";
+
+interface TelegramHandler {
+  filter: Guard<Update>;
+  handler: (ctx: Context, next?: () => Promise<void>) => Promise<void>;
+}
 
 export interface TelegramPluginConfig {
   token?: string; // It's optional so we can load from the environment, but we check it in the constructor to make sure it's set
+
+  handlers: TelegramHandler[]; // Handlers to register
   // Optional configuration
   pollingTimeout?: number; // Polling timeout in seconds
   dropPendingUpdates?: boolean; // Whether to drop pending updates on start
@@ -14,7 +24,9 @@ export interface TelegramMessage {
   username?: string;
 }
 
-export type TelegramContext = Context;
+export interface TelegramContext extends Context {
+  plugin?: PluginTelegram;
+}
 
 export const TelegramResponseSchema = z.object({
   message: z.string()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,9 +82,9 @@ importers:
       "@maiar-ai/plugin-search":
         specifier: workspace:*
         version: link:../packages/plugin-search
-      "@maiar-ai/plugin-terminal":
+      "@maiar-ai/plugin-telegram":
         specifier: workspace:*
-        version: link:../packages/plugin-terminal
+        version: link:../packages/plugin-telegram
       "@maiar-ai/plugin-text":
         specifier: workspace:*
         version: link:../packages/plugin-text
@@ -100,6 +100,9 @@ importers:
       express:
         specifier: 4.21.2
         version: 4.21.2
+      telegraf:
+        specifier: 4.16.3
+        version: 4.16.3(encoding@0.1.13)
     devDependencies:
       "@types/express":
         specifier: 5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       "@maiar-ai/plugin-telegram":
         specifier: workspace:*
         version: link:../packages/plugin-telegram
+      "@maiar-ai/plugin-terminal":
+        specifier: workspace:*
+        version: link:../packages/plugin-terminal
       "@maiar-ai/plugin-text":
         specifier: workspace:*
         version: link:../packages/plugin-text
@@ -436,10 +439,10 @@ importers:
     dependencies:
       "@docusaurus/core":
         specifier: 3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/preset-classic":
         specifier: 3.7.0
-        version: 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+        version: 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
       "@mdx-js/react":
         specifier: 3.1.0
         version: 3.1.0(@types/react@19.0.8)(react@19.0.0)
@@ -461,13 +464,13 @@ importers:
     devDependencies:
       "@docusaurus/module-type-aliases":
         specifier: 3.7.0
-        version: 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/tsconfig":
         specifier: 3.7.0
         version: 3.7.0
       "@docusaurus/types":
         specifier: 3.7.0
-        version: 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/node":
         specifier: 22.13.1
         version: 22.13.1
@@ -14942,7 +14945,7 @@ snapshots:
     transitivePeerDependencies:
       - "@algolia/client-search"
 
-  "@docusaurus/babel@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/babel@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@babel/core": 7.26.7
       "@babel/generator": 7.26.5
@@ -14955,7 +14958,7 @@ snapshots:
       "@babel/runtime-corejs3": 7.26.7
       "@babel/traverse": 7.26.7
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.0
       tslib: 2.8.1
@@ -14969,33 +14972,33 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/bundler@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/bundler@3.7.0(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
       "@babel/core": 7.26.7
-      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/cssnano-preset": 3.7.0
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      babel-loader: 9.2.1(@babel/core@7.26.7)(webpack@5.97.1(esbuild@0.24.2))
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      babel-loader: 9.2.1(@babel/core@7.26.7)(webpack@5.97.1)
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.97.1(esbuild@0.24.2))
-      css-loader: 6.11.0(webpack@5.97.1(esbuild@0.24.2))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
+      copy-webpack-plugin: 11.0.0(webpack@5.97.1)
+      css-loader: 6.11.0(webpack@5.97.1)
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.97.1)
       cssnano: 6.1.2(postcss@8.5.1)
-      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
+      file-loader: 6.2.0(webpack@5.97.1)
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1(esbuild@0.24.2))
-      null-loader: 4.0.1(webpack@5.97.1(esbuild@0.24.2))
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
+      null-loader: 4.0.1(webpack@5.97.1)
       postcss: 8.5.1
-      postcss-loader: 7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
+      postcss-loader: 7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1)
       postcss-preset-env: 10.1.3(postcss@8.5.1)
-      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
-      terser-webpack-plugin: 5.3.11(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
+      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1)
+      terser-webpack-plugin: 5.3.11(webpack@5.97.1)
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2))
-      webpack: 5.97.1(esbuild@0.24.2)
-      webpackbar: 6.0.1(webpack@5.97.1(esbuild@0.24.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1)
+      webpack: 5.97.1
+      webpackbar: 6.0.1(webpack@5.97.1)
     transitivePeerDependencies:
       - "@parcel/css"
       - "@rspack/core"
@@ -15014,15 +15017,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/bundler": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/bundler": 3.7.0(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@mdx-js/react": 3.1.0(@types/react@19.0.8)(react@19.0.0)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -15038,17 +15041,17 @@ snapshots:
       eval: 0.1.8
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(webpack@5.97.1(esbuild@0.24.2))
+      html-webpack-plugin: 5.6.3(webpack@5.97.1)
       leven: 3.1.0
       lodash: 4.17.21
       p-map: 4.0.0
       prompts: 2.4.2
       react: 19.0.0
-      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
+      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1)
       react-dom: 19.0.0(react@19.0.0)
       react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)"
       react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.0.0)"
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1(esbuild@0.24.2))
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1)
       react-router: 5.3.4(react@19.0.0)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0)
       react-router-dom: 5.3.4(react@19.0.0)
@@ -15057,9 +15060,9 @@ snapshots:
       shelljs: 0.8.5
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(webpack@5.97.1(esbuild@0.24.2))
+      webpack-dev-server: 4.15.2(webpack@5.97.1)
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -15093,16 +15096,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  "@docusaurus/mdx-loader@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/mdx-loader@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@mdx-js/mdx": 3.1.0(acorn@8.14.0)
       "@slorber/remark-comment": 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.2.1
-      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
+      file-loader: 6.2.0(webpack@5.97.1)
       fs-extra: 11.3.0
       image-size: 1.2.0
       mdast-util-mdx: 3.0.0
@@ -15118,9 +15121,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1)
       vfile: 6.0.3
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - "@swc/core"
       - acorn
@@ -15129,9 +15132,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/module-type-aliases@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/module-type-aliases@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/history": 4.7.11
       "@types/react": 19.0.8
       "@types/react-router-config": 5.0.11
@@ -15148,17 +15151,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.0
@@ -15170,7 +15173,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15192,17 +15195,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/react-router-config": 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.0
@@ -15212,7 +15215,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15234,18 +15237,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15267,11 +15270,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -15298,11 +15301,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -15327,11 +15330,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/gtag.js": 0.0.12
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -15357,11 +15360,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -15386,14 +15389,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -15420,18 +15423,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@svgr/core": 8.1.0(typescript@5.7.3)
       "@svgr/webpack": 8.1.0(typescript@5.7.3)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15453,22 +15456,22 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
+  "@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-debug": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-google-analytics": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-google-gtag": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-google-tag-manager": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-sitemap": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-svgr": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-classic": 3.7.0(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/theme-search-algolia": 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-debug": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-google-analytics": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-google-gtag": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-google-tag-manager": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-sitemap": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-svgr": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-classic": 3.7.0(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/theme-search-algolia": 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
@@ -15500,21 +15503,21 @@ snapshots:
       "@types/react": 19.0.8
       react: 19.0.0
 
-  "@docusaurus/theme-classic@3.7.0(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/theme-classic@3.7.0(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/theme-translations": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@mdx-js/react": 3.1.0(@types/react@19.0.8)(react@19.0.0)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -15551,13 +15554,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/history": 4.7.11
       "@types/react": 19.0.8
       "@types/react-router-config": 5.0.11
@@ -15576,16 +15579,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
+  "@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
     dependencies:
       "@docsearch/react": 3.8.3(@algolia/client-search@5.20.0)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/theme-translations": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       algoliasearch: 5.20.0
       algoliasearch-helper: 3.24.1(algoliasearch@5.20.0)
       clsx: 2.1.1
@@ -15627,7 +15630,7 @@ snapshots:
 
   "@docusaurus/tsconfig@3.7.0": {}
 
-  "@docusaurus/types@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/types@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@mdx-js/mdx": 3.1.0(acorn@8.14.0)
       "@types/history": 4.7.11
@@ -15638,7 +15641,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)"
       utility-types: 3.11.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - "@swc/core"
@@ -15648,9 +15651,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils-common@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/utils-common@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@swc/core"
@@ -15662,11 +15665,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils-validation@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/utils-validation@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -15682,13 +15685,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/utils@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
+      file-loader: 6.2.0(webpack@5.97.1)
       fs-extra: 11.3.0
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -15701,9 +15704,9 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1)
       utility-types: 3.11.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - "@swc/core"
       - acorn
@@ -17178,12 +17181,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-loader@9.2.1(@babel/core@7.26.7)(webpack@5.97.1(esbuild@0.24.2)):
+  babel-loader@9.2.1(@babel/core@7.26.7)(webpack@5.97.1):
     dependencies:
       "@babel/core": 7.26.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -17757,7 +17760,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.0: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.97.1(esbuild@0.24.2)):
+  copy-webpack-plugin@11.0.0(webpack@5.97.1):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -17765,7 +17768,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
   core-js-compat@3.40.0:
     dependencies:
@@ -17836,7 +17839,7 @@ snapshots:
       postcss-selector-parser: 7.0.0
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.97.1(esbuild@0.24.2)):
+  css-loader@6.11.0(webpack@5.97.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.1)
       postcss: 8.5.1
@@ -17847,9 +17850,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.0
     optionalDependencies:
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.97.1):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.25
       cssnano: 6.1.2(postcss@8.5.1)
@@ -17857,10 +17860,9 @@ snapshots:
       postcss: 8.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     optionalDependencies:
       clean-css: 5.3.3
-      esbuild: 0.24.2
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.1):
     dependencies:
@@ -18576,11 +18578,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)):
+  file-loader@6.2.0(webpack@5.97.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
   file-uri-to-path@1.0.0: {}
 
@@ -18670,7 +18672,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1):
     dependencies:
       "@babel/code-frame": 7.26.2
       "@types/json-schema": 7.0.15
@@ -18686,7 +18688,7 @@ snapshots:
       semver: 7.7.0
       tapable: 1.1.3
       typescript: 5.7.3
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     optionalDependencies:
       eslint: 9.19.0(jiti@2.4.2)
 
@@ -19143,7 +19145,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.97.1(esbuild@0.24.2)):
+  html-webpack-plugin@5.6.3(webpack@5.97.1):
     dependencies:
       "@types/html-minifier-terser": 6.1.0
       html-minifier-terser: 6.1.0
@@ -19151,7 +19153,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
   htmlparser2@6.1.0:
     dependencies:
@@ -20441,11 +20443,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.97.1(esbuild@0.24.2)):
+  mini-css-extract-plugin@2.9.2(webpack@5.97.1):
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.1
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
   minimalistic-assert@1.0.1: {}
 
@@ -20709,11 +20711,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.97.1(esbuild@0.24.2)):
+  null-loader@4.0.1(webpack@5.97.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
   nx@20.4.0:
     dependencies:
@@ -21277,13 +21279,13 @@ snapshots:
       postcss: 8.5.1
       yaml: 2.7.0
 
-  postcss-loader@7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
+  postcss-loader@7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.7.3)
       jiti: 1.21.7
       postcss: 8.5.1
       semver: 7.7.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - typescript
 
@@ -21712,7 +21714,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
+  react-dev-utils@12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1):
     dependencies:
       "@babel/code-frame": 7.26.2
       address: 1.2.2
@@ -21723,7 +21725,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -21738,7 +21740,7 @@ snapshots:
       shell-quote: 1.8.2
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -21769,11 +21771,11 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1(esbuild@0.24.2)):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1):
     dependencies:
       "@babel/runtime": 7.26.7
       react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.0.0)"
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -22641,16 +22643,14 @@ snapshots:
 
   temp-dir@1.0.0: {}
 
-  terser-webpack-plugin@5.3.11(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2)):
+  terser-webpack-plugin@5.3.11(webpack@5.97.1):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.37.0
-      webpack: 5.97.1(esbuild@0.24.2)
-    optionalDependencies:
-      esbuild: 0.24.2
+      webpack: 5.97.1
 
   terser@5.37.0:
     dependencies:
@@ -22982,14 +22982,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
+      file-loader: 6.2.0(webpack@5.97.1)
 
   url-parse@1.5.10:
     dependencies:
@@ -23080,16 +23080,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@5.3.4(webpack@5.97.1(esbuild@0.24.2)):
+  webpack-dev-middleware@5.3.4(webpack@5.97.1):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
 
-  webpack-dev-server@4.15.2(webpack@5.97.1(esbuild@0.24.2)):
+  webpack-dev-server@4.15.2(webpack@5.97.1):
     dependencies:
       "@types/bonjour": 3.5.13
       "@types/connect-history-api-fallback": 1.5.4
@@ -23119,10 +23119,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.97.1(esbuild@0.24.2))
+      webpack-dev-middleware: 5.3.4(webpack@5.97.1)
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -23143,7 +23143,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.97.1(esbuild@0.24.2):
+  webpack@5.97.1:
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.6
@@ -23165,7 +23165,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
+      terser-webpack-plugin: 5.3.11(webpack@5.97.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -23173,7 +23173,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.97.1(esbuild@0.24.2)):
+  webpackbar@6.0.1(webpack@5.97.1):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -23182,7 +23182,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.8.0
-      webpack: 5.97.1(esbuild@0.24.2)
+      webpack: 5.97.1
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       "@types/node":
         specifier: 22.13.1
         version: 22.13.1
+      chokidar-cli:
+        specifier: 3.0.0
+        version: 3.0.0
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
@@ -439,10 +442,10 @@ importers:
     dependencies:
       "@docusaurus/core":
         specifier: 3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/preset-classic":
         specifier: 3.7.0
-        version: 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+        version: 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
       "@mdx-js/react":
         specifier: 3.1.0
         version: 3.1.0(@types/react@19.0.8)(react@19.0.0)
@@ -464,13 +467,13 @@ importers:
     devDependencies:
       "@docusaurus/module-type-aliases":
         specifier: 3.7.0
-        version: 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/tsconfig":
         specifier: 3.7.0
         version: 3.7.0
       "@docusaurus/types":
         specifier: 3.7.0
-        version: 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/node":
         specifier: 22.13.1
         version: 22.13.1
@@ -14945,7 +14948,7 @@ snapshots:
     transitivePeerDependencies:
       - "@algolia/client-search"
 
-  "@docusaurus/babel@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/babel@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@babel/core": 7.26.7
       "@babel/generator": 7.26.5
@@ -14958,7 +14961,7 @@ snapshots:
       "@babel/runtime-corejs3": 7.26.7
       "@babel/traverse": 7.26.7
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.0
       tslib: 2.8.1
@@ -14972,33 +14975,33 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/bundler@3.7.0(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/bundler@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
       "@babel/core": 7.26.7
-      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/cssnano-preset": 3.7.0
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      babel-loader: 9.2.1(@babel/core@7.26.7)(webpack@5.97.1)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      babel-loader: 9.2.1(@babel/core@7.26.7)(webpack@5.97.1(esbuild@0.24.2))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.97.1)
-      css-loader: 6.11.0(webpack@5.97.1)
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.97.1)
+      copy-webpack-plugin: 11.0.0(webpack@5.97.1(esbuild@0.24.2))
+      css-loader: 6.11.0(webpack@5.97.1(esbuild@0.24.2))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
       cssnano: 6.1.2(postcss@8.5.1)
-      file-loader: 6.2.0(webpack@5.97.1)
+      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1)
-      null-loader: 4.0.1(webpack@5.97.1)
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1(esbuild@0.24.2))
+      null-loader: 4.0.1(webpack@5.97.1(esbuild@0.24.2))
       postcss: 8.5.1
-      postcss-loader: 7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1)
+      postcss-loader: 7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
       postcss-preset-env: 10.1.3(postcss@8.5.1)
-      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1)
-      terser-webpack-plugin: 5.3.11(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
+      terser-webpack-plugin: 5.3.11(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1)
-      webpack: 5.97.1
-      webpackbar: 6.0.1(webpack@5.97.1)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2))
+      webpack: 5.97.1(esbuild@0.24.2)
+      webpackbar: 6.0.1(webpack@5.97.1(esbuild@0.24.2))
     transitivePeerDependencies:
       - "@parcel/css"
       - "@rspack/core"
@@ -15017,15 +15020,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/bundler": 3.7.0(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/babel": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/bundler": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@mdx-js/react": 3.1.0(@types/react@19.0.8)(react@19.0.0)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -15041,17 +15044,17 @@ snapshots:
       eval: 0.1.8
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(webpack@5.97.1)
+      html-webpack-plugin: 5.6.3(webpack@5.97.1(esbuild@0.24.2))
       leven: 3.1.0
       lodash: 4.17.21
       p-map: 4.0.0
       prompts: 2.4.2
       react: 19.0.0
-      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1)
+      react-dev-utils: 12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
       react-dom: 19.0.0(react@19.0.0)
       react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)"
       react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.0.0)"
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1(esbuild@0.24.2))
       react-router: 5.3.4(react@19.0.0)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0)
       react-router-dom: 5.3.4(react@19.0.0)
@@ -15060,9 +15063,9 @@ snapshots:
       shelljs: 0.8.5
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(webpack@5.97.1)
+      webpack-dev-server: 4.15.2(webpack@5.97.1(esbuild@0.24.2))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -15096,16 +15099,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  "@docusaurus/mdx-loader@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/mdx-loader@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@mdx-js/mdx": 3.1.0(acorn@8.14.0)
       "@slorber/remark-comment": 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.2.1
-      file-loader: 6.2.0(webpack@5.97.1)
+      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
       fs-extra: 11.3.0
       image-size: 1.2.0
       mdast-util-mdx: 3.0.0
@@ -15121,9 +15124,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2))
       vfile: 6.0.3
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - "@swc/core"
       - acorn
@@ -15132,9 +15135,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/module-type-aliases@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/module-type-aliases@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/history": 4.7.11
       "@types/react": 19.0.8
       "@types/react-router-config": 5.0.11
@@ -15151,17 +15154,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.0
@@ -15173,7 +15176,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15195,17 +15198,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/react-router-config": 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.0
@@ -15215,7 +15218,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15237,18 +15240,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15270,11 +15273,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -15301,11 +15304,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -15330,11 +15333,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/gtag.js": 0.0.12
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -15360,11 +15363,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -15389,14 +15392,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -15423,18 +15426,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@svgr/core": 8.1.0(typescript@5.7.3)
       "@svgr/webpack": 8.1.0(typescript@5.7.3)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -15456,22 +15459,22 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
+  "@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-debug": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-google-analytics": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-google-gtag": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-google-tag-manager": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-sitemap": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-svgr": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-classic": 3.7.0(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/theme-search-algolia": 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-debug": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-google-analytics": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-google-gtag": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-google-tag-manager": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-sitemap": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-svgr": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-classic": 3.7.0(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/theme-search-algolia": 3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
@@ -15503,21 +15506,21 @@ snapshots:
       "@types/react": 19.0.8
       react: 19.0.0
 
-  "@docusaurus/theme-classic@3.7.0(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
+  "@docusaurus/theme-classic@3.7.0(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)":
     dependencies:
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-blog": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/plugin-content-pages": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/theme-translations": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@mdx-js/react": 3.1.0(@types/react@19.0.8)(react@19.0.0)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -15554,13 +15557,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  "@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
-      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/mdx-loader": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/module-type-aliases": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@types/history": 4.7.11
       "@types/react": 19.0.8
       "@types/react-router-config": 5.0.11
@@ -15579,16 +15582,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
+  "@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.20.0)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)":
     dependencies:
       "@docsearch/react": 3.8.3(@algolia/client-search@5.20.0)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)
-      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/core": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
-      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/plugin-content-docs": 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      "@docusaurus/theme-common": 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(acorn@8.14.0)(esbuild@0.24.2)(eslint@9.19.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       "@docusaurus/theme-translations": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-validation": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       algoliasearch: 5.20.0
       algoliasearch-helper: 3.24.1(algoliasearch@5.20.0)
       clsx: 2.1.1
@@ -15630,7 +15633,7 @@ snapshots:
 
   "@docusaurus/tsconfig@3.7.0": {}
 
-  "@docusaurus/types@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/types@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@mdx-js/mdx": 3.1.0(acorn@8.14.0)
       "@types/history": 4.7.11
@@ -15641,7 +15644,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)"
       utility-types: 3.11.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - "@swc/core"
@@ -15651,9 +15654,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils-common@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/utils-common@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@swc/core"
@@ -15665,11 +15668,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils-validation@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/utils-validation@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -15685,13 +15688,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils@3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
+  "@docusaurus/utils@3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)":
     dependencies:
       "@docusaurus/logger": 3.7.0
-      "@docusaurus/types": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/types": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      "@docusaurus/utils-common": 3.7.0(acorn@8.14.0)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.97.1)
+      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
       fs-extra: 11.3.0
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -15704,9 +15707,9 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2))
       utility-types: 3.11.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - "@swc/core"
       - acorn
@@ -17181,12 +17184,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-loader@9.2.1(@babel/core@7.26.7)(webpack@5.97.1):
+  babel-loader@9.2.1(@babel/core@7.26.7)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@babel/core": 7.26.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -17760,7 +17763,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.0: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.97.1):
+  copy-webpack-plugin@11.0.0(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -17768,7 +17771,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
   core-js-compat@3.40.0:
     dependencies:
@@ -17839,7 +17842,7 @@ snapshots:
       postcss-selector-parser: 7.0.0
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.97.1):
+  css-loader@6.11.0(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.1)
       postcss: 8.5.1
@@ -17850,9 +17853,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.0
     optionalDependencies:
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.97.1):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.25
       cssnano: 6.1.2(postcss@8.5.1)
@@ -17860,9 +17863,10 @@ snapshots:
       postcss: 8.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     optionalDependencies:
       clean-css: 5.3.3
+      esbuild: 0.24.2
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.1):
     dependencies:
@@ -18578,11 +18582,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.97.1):
+  file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
   file-uri-to-path@1.0.0: {}
 
@@ -18672,7 +18676,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@babel/code-frame": 7.26.2
       "@types/json-schema": 7.0.15
@@ -18688,7 +18692,7 @@ snapshots:
       semver: 7.7.0
       tapable: 1.1.3
       typescript: 5.7.3
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     optionalDependencies:
       eslint: 9.19.0(jiti@2.4.2)
 
@@ -19145,7 +19149,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.97.1):
+  html-webpack-plugin@5.6.3(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@types/html-minifier-terser": 6.1.0
       html-minifier-terser: 6.1.0
@@ -19153,7 +19157,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -20443,11 +20447,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.97.1):
+  mini-css-extract-plugin@2.9.2(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.1
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
   minimalistic-assert@1.0.1: {}
 
@@ -20711,11 +20715,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.97.1):
+  null-loader@4.0.1(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
   nx@20.4.0:
     dependencies:
@@ -21279,13 +21283,13 @@ snapshots:
       postcss: 8.5.1
       yaml: 2.7.0
 
-  postcss-loader@7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1):
+  postcss-loader@7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.7.3)
       jiti: 1.21.7
       postcss: 8.5.1
       semver: 7.7.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - typescript
 
@@ -21714,7 +21718,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1):
+  react-dev-utils@12.0.1(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@babel/code-frame": 7.26.2
       address: 1.2.2
@@ -21725,7 +21729,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -21740,7 +21744,7 @@ snapshots:
       shell-quote: 1.8.2
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -21771,11 +21775,11 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@babel/runtime": 7.26.7
       react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.0.0)"
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -22643,14 +22647,16 @@ snapshots:
 
   temp-dir@1.0.0: {}
 
-  terser-webpack-plugin@5.3.11(webpack@5.97.1):
+  terser-webpack-plugin@5.3.11(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.37.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
+    optionalDependencies:
+      esbuild: 0.24.2
 
   terser@5.37.0:
     dependencies:
@@ -22982,14 +22988,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.97.1))(webpack@5.97.1):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.97.1)
+      file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
 
   url-parse@1.5.10:
     dependencies:
@@ -23080,16 +23086,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@5.3.4(webpack@5.97.1):
+  webpack-dev-middleware@5.3.4(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
 
-  webpack-dev-server@4.15.2(webpack@5.97.1):
+  webpack-dev-server@4.15.2(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@types/bonjour": 3.5.13
       "@types/connect-history-api-fallback": 1.5.4
@@ -23119,10 +23125,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.97.1)
+      webpack-dev-middleware: 5.3.4(webpack@5.97.1(esbuild@0.24.2))
       ws: 8.18.0
     optionalDependencies:
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -23143,7 +23149,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.97.1:
+  webpack@5.97.1(esbuild@0.24.2):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.6
@@ -23165,7 +23171,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(webpack@5.97.1)
+      terser-webpack-plugin: 5.3.11(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -23173,7 +23179,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.97.1):
+  webpackbar@6.0.1(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -23182,7 +23188,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.8.0
-      webpack: 5.97.1
+      webpack: 5.97.1(esbuild@0.24.2)
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,9 +327,6 @@ importers:
       "@types/node":
         specifier: 22.13.1
         version: 22.13.1
-      chokidar-cli:
-        specifier: 3.0.0
-        version: 3.0.0
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)


### PR DESCRIPTION
## Description

This expands the telegram plugin to allow users to create custom telegraf composers.
The key here is that a user can write custom logic for handling commands and everything else on a `Composer`

- Addition of composer into the `TelegramPluginConfig`
- Inject the `TelegramPlugin::this` into the `Telegraf::Context` 
- Mount the user supplied composer onto `this.bot.on`

Use cases:
A user would likely want to be able to specify their own middlewares and/or custom logic for maintaining state/session/context window. To be agnostic of the implementation details we move the plugin to accept handlers instead of hard coding the handlers in the plugin itself.

- Allow users to specify their own custom response handlers (ie `sendMessage(..., {parse_mode: 'HTML'}). This way information could be added to the context about available formatting options.

## Related Issues

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

Inluded `bot.ts` file in the `maiar-starter`

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
