### PR TITLE
feat(plugin-terminal): make chat script generic

### DIFF
--- a/maiar-starter/package.json
+++ b/maiar-starter/package.json
@@ -19,6 +19,7 @@
     "@maiar-ai/plugin-text": "workspace:*",
     "@maiar-ai/plugin-time": "workspace:*",
     "@maiar-ai/plugin-x": "workspace:*",
+    "@maiar-ai/plugin-terminal": "workspace:*",
     "dotenv": "16.4.7",
     "express": "4.21.2"
   },

--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -25,7 +25,7 @@ import { PluginTime } from "@maiar-ai/plugin-time";
 import { PluginCharacter } from "@maiar-ai/plugin-character";
 import { PluginSearch } from "@maiar-ai/plugin-search";
 import { PluginX } from "@maiar-ai/plugin-x";
-
+import { PluginTerminal } from "@maiar-ai/plugin-terminal";
 import appRouter from "./app";
 // Create and start the agent
 const runtime = createRuntime({
@@ -58,6 +58,10 @@ const runtime = createRuntime({
       email: process.env.X_EMAIL as string,
       mentionsCheckIntervalMins: 10,
       loginRetries: 3
+    }),
+    new PluginTerminal({
+      user: "test",
+      agentName: "maiar-starter"
     })
   ]
 });

--- a/packages/plugin-terminal/package.json
+++ b/packages/plugin-terminal/package.json
@@ -4,8 +4,12 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "maiar-chat": "./dist/scripts/chat.js"
+  },
   "files": [
-    "dist"
+    "dist",
+    "dist/scripts"
   ],
   "exports": {
     ".": {
@@ -38,11 +42,11 @@
     "url": "https://github.com/UraniumCorporation/maiar-ai/issues"
   },
   "scripts": {
-    "dev": "tsup --config ../../tsup.config.base.ts --watch",
+    "dev": "tsup --config ./tsup.config.ts --watch",
     "chat": "NODE_NO_WARNINGS=1 tsc src/scripts/chat.ts && node src/scripts/chat.js",
     "lint": "tsc --project tsconfig.json",
     "lint:emit": "tsc --project tsconfig.json --noEmit false",
-    "build": "tsup --config ../../tsup.config.base.ts",
+    "build": "tsup --config ./tsup.config.ts",
     "clean": "rm -rf dist",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/plugin-terminal/src/index.ts
+++ b/packages/plugin-terminal/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./plugin";
 export * from "./types";
 export * from "./templates";
+export const CHAT_SOCKET_PATH = "/tmp/maiar-chat.sock";

--- a/packages/plugin-terminal/src/types.ts
+++ b/packages/plugin-terminal/src/types.ts
@@ -5,16 +5,28 @@ import { z } from "zod";
  */
 export interface TerminalPluginConfig {
   /**
-   * Prompt prefix for the terminal input
-   * @default '> '
-   */
-  prompt?: string;
-
-  /**
-   * Default user identifier
+   * User identifier
    * @default 'local'
    */
-  defaultUser?: string;
+  user?: string;
+
+  /**
+   * Terminal name
+   * @default 'Terminal'
+   */
+  agentName?: string;
+
+  /**
+   * Maximum number of retries
+   * @default 3
+   */
+  maxRetries?: number;
+
+  /**
+   * Retry delay
+   * @default 1000
+   */
+  retryDelay?: number;
 }
 
 export const TerminalResponseSchema = z.object({

--- a/packages/plugin-terminal/tsconfig.json
+++ b/packages/plugin-terminal/tsconfig.json
@@ -6,5 +6,5 @@
     "declaration": true,
     "declarationDir": "./dist"
   },
-  "include": ["src/index.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/plugin-terminal/tsup.config.ts
+++ b/packages/plugin-terminal/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+import { chmod } from "fs/promises";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "scripts/chat": "src/scripts/chat.ts"
+  },
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  async onSuccess() {
+    await chmod("dist/scripts/chat.js", "755");
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       "@maiar-ai/plugin-search":
         specifier: workspace:*
         version: link:../packages/plugin-search
+      "@maiar-ai/plugin-terminal":
+        specifier: workspace:*
+        version: link:../packages/plugin-terminal
       "@maiar-ai/plugin-text":
         specifier: workspace:*
         version: link:../packages/plugin-text


### PR DESCRIPTION
## Description

The current `chat.ts` script in the `plugin-terminal` package is not built and included in the npm package. It is also hardcoded with values that a user would want to configure. This PR solve the following issues.
- Chat script is not built along with the rest of the plugin
- `pnpm` script included to easily launch chat session
- Refactored `chat.ts` that is configurable via the plugin terminal setup

## Related Issues

Closes #26 

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

**Terminal 1**
```bash
# root of the project
pnpm dev
```

**Terminal 2**
```bash
cd maiar-starter
pnpm dev
```

**Terminal 3**
```bash
pnpm maiar-chat
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
