### PR TITLE
docs(website): 🧩 add register plugin button

### DIFF
--- a/website/src/css/plugins.module.css
+++ b/website/src/css/plugins.module.css
@@ -11,7 +11,6 @@
 }
 
 .searchContainer {
-  margin-bottom: 2rem;
   display: flex;
   justify-content: center;
   padding: 1rem;
@@ -40,7 +39,6 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
-  margin: 0.5rem 0;
 }
 
 .pluginItem {
@@ -329,4 +327,28 @@
   .pluginNameVersion {
     margin-bottom: 1rem;
   }
+}
+
+.registerPluginContainer {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.registerPluginLink {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  background: rgba(194, 255, 102, 0.15);
+  color: #c2ff66;
+  text-decoration: none;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+  border: 1px solid rgba(194, 255, 102, 0.3);
+}
+
+.registerPluginLink:hover {
+  background: rgba(194, 255, 102, 0.25);
+  color: #d1ff8c;
+  text-decoration: none;
+  border-color: rgba(194, 255, 102, 0.5);
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -220,6 +220,8 @@ export default function Home(): JSX.Element {
               overflow: hidden;
               background: #000;
               color: #88ff88;
+              word-break: break-word;
+              overflow-wrap: break-word;
             }
             .homepage {
               padding: 0 !important;
@@ -346,16 +348,21 @@ export default function Home(): JSX.Element {
               margin-top: 10px;
               text-align: center;
               z-index: 6;
+              display: flex;
+              flex-wrap: wrap;
+              justify-content: center;
+              gap: 15px;
             }
             .links a {
               color: #88ff88;
               text-decoration: none;
-              margin: 0 15px;
               font-size: 1rem;
               transition: color 0.3s;
+              white-space: nowrap;
+              padding: 5px;
             }
             .links a:hover {
-              color: #aaffaa;
+              color: #c2ff66;
             }
             .grain {
               position: fixed;

--- a/website/src/pages/plugins.tsx
+++ b/website/src/pages/plugins.tsx
@@ -241,6 +241,16 @@ export default function Plugins(): React.JSX.Element {
             onChange={(e) => setSearchQuery(e.target.value)}
             className={styles.searchInput}
           />
+          <div className={styles.registerPluginContainer}>
+            <a
+              href="https://github.com/UraniumCorporation/plugin-registry"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.registerPluginLink}
+            >
+              🔌 Register your plugin
+            </a>
+          </div>
           {error && <div className={styles.errorMessage}>{error}</div>}
         </div>
 


### PR DESCRIPTION


## Description

- 🧩 add register plugin button in the /plugins page
- 🐛 fixes home page box being too wide for screen size by using word-break

## Related Issues

No link to plugin-registry on docs website in official/community plugins listing page

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [x] Documentation updated

## How to Test

```
# From root directory
cd website
pnpm start
```

```
pnpm build:website
pnpm serve
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
