### PR TITLE
ci(bounty,thank-you): 🐛 fix GHA workflow dependency installation for bounty program

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -42,6 +42,8 @@ const commitlintConfig: UserConfig = {
         "ci", // Continuous integration
         "cd", // Continuous deployment
         "release", // Release related changes
+        "bounty", // Bounty CI related changes
+        "thank-you", // Thank you CI related changes
         "other", // Other changes
         "core", // core package
         "memory-filesystem", // memory-filesystem plugin

--- a/.github/workflows/bounty.yaml
+++ b/.github/workflows/bounty.yaml
@@ -19,7 +19,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: |
-          npm install --save-exact @actions/github@6.0.0
+          npm install -g pnpm
+          pnpm install --save-exact @actions/github@6.0.0
 
       # Step Outputs:
       # - issues (string) - "1, 2, 3" (csv) or ""

--- a/.github/workflows/thank-you.yaml
+++ b/.github/workflows/thank-you.yaml
@@ -15,7 +15,8 @@ jobs:
 
       - name: 📦 Install dependencies
         run: |
-          npm install --save-exact @actions/github@6.0.0
+          npm install -g pnpm
+          pnpm install --save-exact @actions/github@6.0.0
 
       - name: 🎉 Thank Contributor
         run: node .github/scripts/thank-you/thank-contributor.js

--- a/website/src/pages/plugins.tsx
+++ b/website/src/pages/plugins.tsx
@@ -85,7 +85,8 @@ export default function Plugins(): React.JSX.Element {
             item.type === "dir" &&
             (item.name.startsWith("plugin-") ||
               item.name.startsWith("memory-") ||
-              item.name.startsWith("model-"))
+              item.name.startsWith("model-") ||
+              item.name.startsWith("monitor-"))
         );
 
         // Transform directory data into official plugin format
@@ -108,7 +109,9 @@ export default function Plugins(): React.JSX.Element {
                   ? "plugin"
                   : dir.name.startsWith("memory-")
                     ? "memory package"
-                    : "model package"
+                    : dir.name.startsWith("monitor-")
+                      ? "monitor package"
+                      : "model package"
               } for Maiar framework`,
               author: repoData.organization.login,
               authorAvatar: `${repoData.organization.avatar_url}&s=48`,
@@ -120,7 +123,9 @@ export default function Plugins(): React.JSX.Element {
                   ? "plugin"
                   : dir.name.startsWith("memory-")
                     ? "memory"
-                    : "model",
+                    : dir.name.startsWith("monitor-")
+                      ? "monitor"
+                      : "model",
                 dir.name.split("-")[1]
               ],
               isOfficial: true,


### PR DESCRIPTION
## Description

1. 🐛 GHA Fix - For both the `bounty.yaml` and `thank-you.yaml` GHA workflow, download `pnpm` globally first with `npm` then use `pnpm` to download dependencies

2. 🐛 monitor plugin display fix - Loop packages dir and parse anything that starts with `monitor-` to display those plugins on the docs website

## Related Issues

1. GHA Workflow for `bounty.yaml` and `thank-you.yaml` was failing during the `📦 Install Dependencies` step since it was downloading dependencies using `npm` instead of `pnpm` which is what the monorepo uses
2. monitor plugins are not displaying on the docusaurus website page

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [x] Documentation updated

## How to Test

For GHA workflow:
1. create a new workflow called .github/test.yaml
2. add a step that installs dependencies using:
```
- name: 📦 Install dependencies
  run: |
    npm install -g pnpm
    pnpm install --save-exact @actions/github@6.0.0
```

For docusaurus website:
```
cd website
pnpm start
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
