### PR TITLE
ci(bounty,thank-you): 🐛 convert commonjs imports to esm imports

### DIFF
--- a/.github/scripts/bounty/calculate-bounty.js
+++ b/.github/scripts/bounty/calculate-bounty.js
@@ -1,5 +1,5 @@
-const { appendFileSync } = require("fs");
-const { GithubService, MAIAR_SYMBOL } = require("../lib/github");
+import { appendFileSync } from "fs";
+import { GithubService, MAIAR_SYMBOL } from "../lib/github.js";
 
 /**
  * Main function that calculates the bounty amount for a PR

--- a/.github/scripts/bounty/extract-issues.js
+++ b/.github/scripts/bounty/extract-issues.js
@@ -1,5 +1,5 @@
-const { appendFileSync } = require("fs");
-const { GithubService } = require("../lib/github");
+import { appendFileSync } from "fs";
+import { GithubService } from "../lib/github.js";
 
 /**
  * Main function that extracts issue numbers from CODEOWNER comments from a PR

--- a/.github/scripts/bounty/extract-wallet.js
+++ b/.github/scripts/bounty/extract-wallet.js
@@ -1,5 +1,5 @@
-const { appendFileSync } = require("fs");
-const { GithubService } = require("../lib/github");
+import { appendFileSync } from "fs";
+import { GithubService } from "../lib/github.js";
 
 /**
  * Main function that calculates the bounty amount for a PR

--- a/.github/scripts/bounty/filter-bounty-issues.js
+++ b/.github/scripts/bounty/filter-bounty-issues.js
@@ -1,5 +1,5 @@
-const { appendFileSync } = require("fs");
-const { GithubService, BOUNTY_PAID_LABEL } = require("../lib/github");
+import { appendFileSync } from "fs";
+import { GithubService, BOUNTY_PAID_LABEL } from "../lib/github.js";
 
 /**
  * Main function that filters bounty issues that have not been paid

--- a/.github/scripts/bounty/label-issues-paid.js
+++ b/.github/scripts/bounty/label-issues-paid.js
@@ -1,4 +1,4 @@
-const { GithubService, BOUNTY_PAID_LABEL } = require("../lib/github");
+import { GithubService, BOUNTY_PAID_LABEL } from "../lib/github.js";
 
 /**
  * Main function that labels bounty issues on Github with the `bounty paid` label

--- a/.github/scripts/bounty/thank-contributor-tx.js
+++ b/.github/scripts/bounty/thank-contributor-tx.js
@@ -1,4 +1,4 @@
-const { GithubService } = require("../lib/github");
+import { GithubService } from "../lib/github.js";
 
 /**
  * Main function that makes a comment on the PR with the bounty payment details

--- a/.github/scripts/lib/github.js
+++ b/.github/scripts/lib/github.js
@@ -1,15 +1,15 @@
-const { readFileSync } = require("fs");
-const { getOctokit } = require("@actions/github");
+import { readFileSync } from "fs";
+import { getOctokit } from "@actions/github";
 
 // Constants
-const MAIAR_SYMBOL = "$MAIAR";
-const BOUNTY_LABEL = "bounty";
-const BOUNTY_PAID_LABEL = "bounty paid";
+export const MAIAR_SYMBOL = "$MAIAR";
+export const BOUNTY_LABEL = "bounty";
+export const BOUNTY_PAID_LABEL = "bounty paid";
 
 /**
  * Service class to interact with GitHub API
  */
-class GithubService {
+export class GithubService {
   /**
    * Initialize the GitHub service
    * @param {string} githubToken - GitHub API token
@@ -134,10 +134,3 @@ class GithubService {
     return `<sub>This comment was created by GitHub Actions workflow run [#${runId}](https://github.com/${this.owner}/${this.repoName}/actions/runs/${runId}) on ${runDate}</sub>`;
   }
 }
-
-module.exports = {
-  GithubService,
-  BOUNTY_LABEL,
-  BOUNTY_PAID_LABEL,
-  MAIAR_SYMBOL
-};

--- a/.github/scripts/thank-you/thank-contributor.js
+++ b/.github/scripts/thank-you/thank-contributor.js
@@ -1,4 +1,4 @@
-const { GithubService } = require("../lib/github");
+import { GithubService } from "../lib/github.js";
 
 /**
  * Main function that thanks the contributor for their contribution


### PR DESCRIPTION
## Description

Convert all imports in `.github/scripts/**/*.js` to use ESM import syntax instead of CommonJS

## Related Issues

Bounty Payment and Thank you GHA workflow jobs failing due to the root package.json declaring all JS files to be treated as ESM modules so commonJS imports in the current code do not work when trying to run it with node:
- https://github.com/UraniumCorporation/maiar-ai/actions/runs/13826794345/job/38683132367
- https://github.com/UraniumCorporation/maiar-ai/actions/runs/13826794342/job/38683132318

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

In the root run `pnpm i -w --save-exact @actions/github@6.0.0`
Then run `node .github/scripts/bounty/*.js` or `node .github/scripts/thank-you/*.js`

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
