### PR TITLE
ci(bounty,thank-you): 🐛 add permissions for GITHUB_TOKEN to write to PRs/issues

### DIFF
--- a/.github/workflows/bounty.yaml
+++ b/.github/workflows/bounty.yaml
@@ -13,6 +13,9 @@ jobs:
     # Only run this job when the PR is merged
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/thank-you.yaml
+++ b/.github/workflows/thank-you.yaml
@@ -9,6 +9,9 @@ jobs:
     # Only run this job when the PR is merged
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Adds explicit permissions on the GHA workflow `issues: write` and `pull-requests: write`

## Related Issues

Github actions' default `GITHUB_TOKEN` has read-only permissions unless explicitly overridden. adding `permissions: issues: write` lets it comment on issues/prs.

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Read these docs
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
