### PR TITLE
ci(bounty,thank-you): 🐛 add content write permission for GITHUB_TOKEN to write to PRs/issues

### DIFF
--- a/.github/workflows/bounty.yaml
+++ b/.github/workflows/bounty.yaml
@@ -14,6 +14,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
       issues: write
     steps:

--- a/.github/workflows/thank-you.yaml
+++ b/.github/workflows/thank-you.yaml
@@ -10,6 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
       issues: write
     steps:


### PR DESCRIPTION
## Description

Adds explicit permissions on the GHA workflow `content: write`

## Related Issues

Github actions' default `GITHUB_TOKEN` has read-only permissions unless explicitly overridden

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Read these docs
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
