### PR TITLE
ci(bounty,thank-you): 🐛 set write permissions to write-all

### DIFF
--- a/.github/workflows/bounty.yaml
+++ b/.github/workflows/bounty.yaml
@@ -13,10 +13,7 @@ jobs:
     # Only run this job when the PR is merged
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+    permissions: write-all
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/thank-you.yaml
+++ b/.github/workflows/thank-you.yaml
@@ -9,10 +9,7 @@ jobs:
     # Only run this job when the PR is merged
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+    permissions: write-all
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Adds `permissions: write-all` on the GHA workflow `bounty.yaml` and `thank-you.yaml`

## Related Issues

Github actions' default `GITHUB_TOKEN` has read-only permissions unless explicitly overridden

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Read these docs
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes

Tested in my fork - https://github.com/k3v-d3v/maiar-ai/actions/runs/13830667851/job/38694032070

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
