### PR TITLE
ci(bounty,thank-you): 🐛 use pull_request_target trigger

### DIFF
--- a/.github/workflows/bounty.yaml
+++ b/.github/workflows/bounty.yaml
@@ -1,6 +1,6 @@
 name: 💰 Bounty Payment
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 env:

--- a/.github/workflows/thank-you.yaml
+++ b/.github/workflows/thank-you.yaml
@@ -1,6 +1,6 @@
 name: 🎉 Thank Contributor
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
## Description

use the trigger `pull_request_target` in GHA workflows `bounty.yaml` and `thank-you.yaml`

## Related Issues

When a contributor forks your repo and raises a Pull Request from that fork the token they get will be read only. So we can’t use it to make comments

- https://jacobtomlinson.dev/posts/2022/commenting-on-pull-requests-with-github-actions/
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

- Tested in k3v-d3v fork
   - https://github.com/k3v-d3v/maiar-ai/actions/runs/13844974550/workflow
   - https://github.com/k3v-d3v/maiar-ai/actions/runs/13844974550/job/38741244802

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
