### PR TITLE
chore: fix scrolling behavior in client + status resize bug

### DIFF
--- a/maiar-client/src/components/CurrentPipeline.tsx
+++ b/maiar-client/src/components/CurrentPipeline.tsx
@@ -1,5 +1,6 @@
 import { Paper, Typography, Box } from "@mui/material";
 import { PipelineSteps } from "./PipelineSteps";
+import { useRef, useEffect, useState } from "react";
 
 interface CurrentPipelineProps {
   pipeline?: Array<{ pluginId: string; action: string }>;
@@ -14,6 +15,58 @@ export function CurrentPipeline({
   modifiedSteps,
   explanation
 }: CurrentPipelineProps) {
+  const pipelineContainerRef = useRef<HTMLDivElement>(null);
+  const [shouldAutoScroll, setShouldAutoScroll] = useState<boolean>(true);
+  const prevPipelineRef = useRef<typeof pipeline>(pipeline);
+  const prevCurrentStepRef = useRef<typeof currentStep>(currentStep);
+
+  // Handle scroll events to determine if auto-scroll should be enabled
+  const handleScroll = () => {
+    if (pipelineContainerRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } =
+        pipelineContainerRef.current;
+      // If user is near the bottom (within 20px), enable auto-scrolling
+      setShouldAutoScroll(scrollHeight - scrollTop - clientHeight < 20);
+    }
+  };
+
+  // Auto-scroll to bottom when pipeline updates, but only if we should auto-scroll
+  useEffect(() => {
+    // Check if the pipeline has changed and we should auto-scroll
+    const hasPipelineChanged =
+      pipeline &&
+      (!prevPipelineRef.current ||
+        prevPipelineRef.current.length !== pipeline.length);
+
+    // Check if currentStep has changed
+    const hasCurrentStepChanged =
+      (currentStep && !prevCurrentStepRef.current) ||
+      (!currentStep && prevCurrentStepRef.current) ||
+      (currentStep &&
+        prevCurrentStepRef.current &&
+        (currentStep.pluginId !== prevCurrentStepRef.current.pluginId ||
+          currentStep.action !== prevCurrentStepRef.current.action));
+
+    if (
+      shouldAutoScroll &&
+      (hasPipelineChanged || hasCurrentStepChanged) &&
+      pipelineContainerRef.current
+    ) {
+      // Use requestAnimationFrame to ensure the DOM has updated before scrolling
+      requestAnimationFrame(() => {
+        if (pipelineContainerRef.current) {
+          // Directly set the scrollTop to the bottom
+          pipelineContainerRef.current.scrollTop =
+            pipelineContainerRef.current.scrollHeight;
+        }
+      });
+    }
+
+    // Update the previous refs
+    prevPipelineRef.current = pipeline;
+    prevCurrentStepRef.current = currentStep;
+  }, [pipeline, currentStep, shouldAutoScroll]);
+
   if (!pipeline) {
     return (
       <Paper
@@ -57,11 +110,13 @@ export function CurrentPipeline({
       }}
     >
       <Box
+        ref={pipelineContainerRef}
         sx={{
           flex: 1,
           overflow: "auto",
           p: 3
         }}
+        onScroll={handleScroll}
       >
         <Box
           sx={{

--- a/maiar-client/src/components/GridLayout.tsx
+++ b/maiar-client/src/components/GridLayout.tsx
@@ -28,21 +28,21 @@ type LayoutType = {
 // Define the layout for different breakpoints
 const DEFAULT_LAYOUTS: LayoutType = {
   lg: [
-    { i: "status", x: 0, y: 0, w: 12, h: 2, minW: 12, minH: 2, static: true },
+    { i: "status", x: 0, y: 0, w: 12, h: 4, minW: 12, minH: 3 },
     { i: "pipeline", x: 0, y: 2, w: 4, h: 12, minW: 3, minH: 6 },
     { i: "contextChain", x: 4, y: 2, w: 4, h: 12, minW: 3, minH: 6 },
     { i: "chat", x: 8, y: 2, w: 4, h: 6, minW: 3, minH: 4 },
     { i: "events", x: 8, y: 8, w: 4, h: 6, minW: 3, minH: 4 }
   ],
   md: [
-    { i: "status", x: 0, y: 0, w: 12, h: 2, minW: 12, minH: 2, static: true },
+    { i: "status", x: 0, y: 0, w: 12, h: 4, minW: 12, minH: 3 },
     { i: "pipeline", x: 0, y: 2, w: 6, h: 12, minW: 3, minH: 6 },
     { i: "contextChain", x: 6, y: 2, w: 6, h: 12, minW: 3, minH: 6 },
     { i: "chat", x: 0, y: 14, w: 6, h: 6, minW: 3, minH: 4 },
     { i: "events", x: 6, y: 14, w: 6, h: 6, minW: 3, minH: 4 }
   ],
   sm: [
-    { i: "status", x: 0, y: 0, w: 12, h: 2, minW: 12, minH: 2, static: true },
+    { i: "status", x: 0, y: 0, w: 12, h: 4, minW: 12, minH: 3 },
     { i: "pipeline", x: 0, y: 2, w: 12, h: 8, minW: 3, minH: 6 },
     { i: "contextChain", x: 0, y: 10, w: 12, h: 8, minW: 3, minH: 6 },
     { i: "chat", x: 0, y: 18, w: 12, h: 6, minW: 3, minH: 4 },


### PR DESCRIPTION
## Description
There was an annoying behavior where new items in the chat, event queue, and context chain elements that would cause the parent scroll view to jump to those elements when new events entered their feeds. This is because I was using `scrollIntoView` which causes the entire parent view to move.

This new change simply scrolls the child element to the latest item on the queue by scrolling all the way down for new events received.

Also fixed the bug that prevented agent status from being resizable.

## Changes Made
- [x] Bug fixed

## How to Test
Use `maiar-chat` and stack event panels top to bottom. In old maiar-chat, your parent scrollview will jump around as new items enter the feed. With this update, the parent view stays in the same place while all the child elements will scroll to the newest item in their containers.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
