### PR TITLE
feat: add postgres memory provider

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -47,6 +47,7 @@ const commitlintConfig: UserConfig = {
         "other", // Other changes
         "core", // core package
         "memory-filesystem", // memory-filesystem plugin
+        "memory-postgres", // memory-postgres plugin
         "memory-sqlite", // memory-sqlite plugin
         "model-ollama", // model-ollama plugin
         "model-openai", // model-openai plugin

--- a/maiar-starter/package.json
+++ b/maiar-starter/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@maiar-ai/core": "workspace:*",
     "@maiar-ai/memory-sqlite": "workspace:*",
+    "@maiar-ai/memory-postgres": "workspace:*",
     "@maiar-ai/model-openai": "workspace:*",
     "@maiar-ai/monitor-console": "workspace:*",
     "@maiar-ai/monitor-websocket": "workspace:*",

--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -15,7 +15,7 @@ config({
 import { createRuntime } from "@maiar-ai/core";
 
 // Import providers
-import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
+import { PostgresProvider } from "@maiar-ai/memory-postgres";
 import {
   OpenAIImageGenerationModel,
   OpenAIProvider,
@@ -50,8 +50,8 @@ const runtime = createRuntime({
       apiKey: process.env.OPENAI_API_KEY as string
     })
   ],
-  memory: new SQLiteProvider({
-    dbPath: path.join(process.cwd(), "data", "conversations.db")
+  memory: new PostgresProvider({
+    connectionString: process.env.DATABASE_URL as string
   }),
   monitor: [
     new ConsoleMonitorProvider(),

--- a/packages/memory-postgres/README.md
+++ b/packages/memory-postgres/README.md
@@ -1,0 +1,8 @@
+# @maiar-ai/memory-postgres
+
+This package is part of the [Maiar](https://maiar.dev) ecosystem, designed to work seamlessly with `@maiar-ai/core`.
+
+## Documentation
+
+For detailed documentation, examples, and API reference, visit:
+https://maiar.dev/docs

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@maiar-ai/memory-postgres",
+  "version": "0.13.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "description": "Maiar: A Composable, Plugin-Based AI Agent Framework",
+  "keywords": [
+    "ai",
+    "agent",
+    "framework",
+    "plugin",
+    "postgres",
+    "postgresql"
+  ],
+  "author": "UraniumCorporation <contact@maiar.dev> (https://maiar.dev)",
+  "license": "MIT",
+  "homepage": "https://maiar.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UraniumCorporation/maiar-ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/UraniumCorporation/maiar-ai/issues"
+  },
+  "scripts": {
+    "dev": "tsup --config ../../tsup.config.base.ts --watch",
+    "lint": "tsc --project tsconfig.json",
+    "lint:emit": "tsc --project tsconfig.json --noEmit false",
+    "build": "tsup --config ../../tsup.config.base.ts",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
+  },
+  "dependencies": {
+    "@maiar-ai/core": "workspace:*",
+    "pg": "^8.11.3",
+    "pg-pool": "^3.6.1"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.4",
+    "@types/node": "22.13.1",
+    "tsup": "8.3.6",
+    "typescript": "5.7.3"
+  }
+}

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -48,11 +48,11 @@
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",
-    "pg": "8.11.3",
+    "pg": "8.14.1",
     "pg-pool": "3.6.1"
   },
   "devDependencies": {
-    "@types/pg": "8.11.4",
+    "@types/pg": "8.11.11",
     "@types/node": "22.13.1",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -52,7 +52,7 @@
     "pg-pool": "3.6.1"
   },
   "devDependencies": {
-    "@types/pg": "^8.11.4",
+    "@types/pg": "8.11.4",
     "@types/node": "22.13.1",
     "tsup": "8.3.6",
     "typescript": "5.7.3"

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -48,8 +48,8 @@
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",
-    "pg": "^8.11.3",
-    "pg-pool": "^3.6.1"
+    "pg": "8.11.3",
+    "pg-pool": "3.6.1"
   },
   "devDependencies": {
     "@types/pg": "^8.11.4",

--- a/packages/memory-postgres/src/index.ts
+++ b/packages/memory-postgres/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./provider";

--- a/packages/memory-postgres/src/provider.ts
+++ b/packages/memory-postgres/src/provider.ts
@@ -1,0 +1,299 @@
+import { Pool } from "pg";
+import { createLogger } from "@maiar-ai/core";
+import {
+  MemoryProvider,
+  Message,
+  Context,
+  Conversation,
+  MemoryQueryOptions
+} from "@maiar-ai/core";
+
+const log = createLogger("memory:postgres");
+
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue };
+
+export interface PostgresConfig {
+  connectionString: string;
+  ssl?: boolean;
+  max?: number; // maximum number of clients in pool
+}
+
+export class PostgresProvider implements MemoryProvider {
+  readonly id = "postgres";
+  readonly name = "PostgreSQL Memory";
+  readonly description = "Stores conversations in a PostgreSQL database";
+
+  private pool: Pool;
+
+  constructor(config: PostgresConfig) {
+    this.pool = new Pool({
+      connectionString: config.connectionString,
+      ssl: config.ssl,
+      max: config.max || 20
+    });
+    this.initializeStorage();
+    this.checkHealth();
+  }
+
+  private async checkHealth() {
+    try {
+      const client = await this.pool.connect();
+      try {
+        await client.query("SELECT 1");
+        log.info({ msg: "PostgreSQL health check passed" });
+      } finally {
+        client.release();
+      }
+    } catch (error) {
+      log.error({ msg: "PostgreSQL health check failed", error });
+      throw new Error(
+        `Failed to initialize PostgreSQL database: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  private async initializeStorage() {
+    try {
+      await this.createTables();
+      log.info({ msg: "Initialized PostgreSQL memory storage" });
+    } catch (error) {
+      log.error({ msg: "Failed to initialize storage", error });
+      throw error;
+    }
+  }
+
+  private async createTables(): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS conversations (
+          id TEXT PRIMARY KEY,
+          user_id TEXT NOT NULL,
+          platform TEXT NOT NULL,
+          created_at BIGINT NOT NULL,
+          metadata JSONB
+        );
+
+        CREATE TABLE IF NOT EXISTS messages (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          content TEXT NOT NULL,
+          timestamp BIGINT NOT NULL,
+          context_id TEXT,
+          user_message_id TEXT,
+          FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+          FOREIGN KEY (user_message_id) REFERENCES messages(id) ON DELETE SET NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS contexts (
+          id TEXT PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          content TEXT NOT NULL,
+          timestamp BIGINT NOT NULL,
+          FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+        );
+      `);
+    } finally {
+      client.release();
+    }
+  }
+
+  async createConversation(options?: {
+    id?: string;
+    metadata?: Record<string, JSONValue>;
+  }): Promise<string> {
+    const id = options?.id || Math.random().toString(36).substring(2);
+    const [user, platform] = id.split("-");
+    const timestamp = Date.now();
+
+    log.info({ msg: "Creating new conversation", id });
+    try {
+      const client = await this.pool.connect();
+      try {
+        await client.query(
+          "INSERT INTO conversations (id, user_id, platform, created_at, metadata) VALUES ($1, $2, $3, $4, $5)",
+          [
+            id,
+            user,
+            platform,
+            timestamp,
+            options?.metadata ? JSON.stringify(options.metadata) : null
+          ]
+        );
+        log.info({ msg: "Created conversation successfully", id });
+        return id;
+      } finally {
+        client.release();
+      }
+    } catch (error) {
+      log.error({ msg: "Failed to create conversation", id, error });
+      throw error;
+    }
+  }
+
+  async storeMessage(message: Message, conversationId: string): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(
+        `INSERT INTO messages (id, conversation_id, role, content, timestamp, context_id, user_message_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          message.id,
+          conversationId,
+          message.role,
+          message.content,
+          message.timestamp,
+          message.contextId,
+          message.user_message_id
+        ]
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async storeContext(context: Context, conversationId: string): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(
+        `INSERT INTO contexts (id, conversation_id, type, content, timestamp)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          context.id,
+          conversationId,
+          context.type,
+          context.content,
+          context.timestamp
+        ]
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async getMessages(options: MemoryQueryOptions): Promise<Message[]> {
+    if (!options.conversationId) {
+      throw new Error(
+        "Conversation ID is required for PostgreSQL memory provider"
+      );
+    }
+
+    let query = "SELECT * FROM messages WHERE conversation_id = $1";
+    const params: (string | number)[] = [options.conversationId];
+    let paramCount = 1;
+
+    if (options.after) {
+      paramCount++;
+      query += ` AND timestamp > $${paramCount}`;
+      params.push(options.after);
+    }
+
+    if (options.before) {
+      paramCount++;
+      query += ` AND timestamp < $${paramCount}`;
+      params.push(options.before);
+    }
+
+    query += " ORDER BY timestamp DESC";
+
+    if (options.limit) {
+      paramCount++;
+      query += ` LIMIT $${paramCount}`;
+      params.push(options.limit);
+    }
+
+    const client = await this.pool.connect();
+    try {
+      const result = await client.query(query, params);
+      return result.rows as Message[];
+    } finally {
+      client.release();
+    }
+  }
+
+  async getContexts(conversationId: string): Promise<Context[]> {
+    const client = await this.pool.connect();
+    try {
+      const result = await client.query(
+        "SELECT * FROM contexts WHERE conversation_id = $1",
+        [conversationId]
+      );
+      return result.rows as Context[];
+    } finally {
+      client.release();
+    }
+  }
+
+  async getConversation(conversationId: string): Promise<Conversation> {
+    log.info({ msg: "Fetching conversation", conversationId });
+
+    const client = await this.pool.connect();
+    try {
+      const conversationResult = await client.query(
+        "SELECT * FROM conversations WHERE id = $1",
+        [conversationId]
+      );
+
+      if (conversationResult.rows.length === 0) {
+        log.error({ msg: "Conversation not found", conversationId });
+        throw new Error(`Conversation not found: ${conversationId}`);
+      }
+
+      const conversation = conversationResult.rows[0];
+      const messages = await this.getMessages({ conversationId });
+      const contexts = await this.getContexts(conversationId);
+
+      log.info({
+        msg: "Retrieved conversation",
+        conversationId,
+        messageCount: messages.length,
+        contextCount: contexts.length
+      });
+
+      return {
+        id: conversationId,
+        messages,
+        contexts,
+        metadata: conversation.metadata
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async deleteConversation(conversationId: string): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      try {
+        // Due to CASCADE constraints, we only need to delete the conversation
+        await client.query("DELETE FROM conversations WHERE id = $1", [
+          conversationId
+        ]);
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        log.error({
+          msg: "Failed to delete conversation",
+          conversationId,
+          error
+        });
+        throw error;
+      }
+    } finally {
+      client.release();
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+}

--- a/packages/memory-postgres/tsconfig.json
+++ b/packages/memory-postgres/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationDir": "./dist"
+  },
+  "include": ["src/index.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,18 +258,18 @@ importers:
         specifier: workspace:*
         version: link:../core
       pg:
-        specifier: 8.11.3
-        version: 8.11.3
+        specifier: 8.14.1
+        version: 8.14.1
       pg-pool:
         specifier: 3.6.1
-        version: 3.6.1(pg@8.11.3)
+        version: 3.6.1(pg@8.14.1)
     devDependencies:
       "@types/node":
         specifier: 22.13.1
         version: 22.13.1
       "@types/pg":
-        specifier: 8.11.4
-        version: 8.11.4
+        specifier: 8.11.11
+        version: 8.11.11
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
@@ -4491,10 +4491,10 @@ packages:
         integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
       }
 
-  "@types/pg@8.11.4":
+  "@types/pg@8.11.11":
     resolution:
       {
-        integrity: sha512-yw3Bwbda6vO+NvI1Ue/YKOwtl31AYvvd/e73O3V4ZkNzuGpTDndLSyc0dQRB2xrQqDePd20pEGIfqSp/GH3pRw==
+        integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==
       }
 
   "@types/prismjs@1.26.5":
@@ -5472,13 +5472,6 @@ packages:
       {
         integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
       }
-
-  buffer-writer@2.0.0:
-    resolution:
-      {
-        integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
-      }
-    engines: { node: ">=4" }
 
   buffer@5.7.1:
     resolution:
@@ -10878,12 +10871,6 @@ packages:
       }
     engines: { node: ">=14.16" }
 
-  packet-reader@1.0.0:
-    resolution:
-      {
-        integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
-      }
-
   pacote@18.0.6:
     resolution:
       {
@@ -11102,6 +11089,14 @@ packages:
     peerDependencies:
       pg: ">=8.0"
 
+  pg-pool@3.8.0:
+    resolution:
+      {
+        integrity: sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==
+      }
+    peerDependencies:
+      pg: ">=8.0"
+
   pg-protocol@1.8.0:
     resolution:
       {
@@ -11122,10 +11117,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  pg@8.11.3:
+  pg@8.14.1:
     resolution:
       {
-        integrity: sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==
+        integrity: sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==
       }
     engines: { node: ">= 8.0.0" }
     peerDependencies:
@@ -18140,7 +18135,7 @@ snapshots:
 
   "@types/parse-json@4.0.2": {}
 
-  "@types/pg@8.11.4":
+  "@types/pg@8.11.11":
     dependencies:
       "@types/node": 22.13.1
       pg-protocol: 1.8.0
@@ -18825,8 +18820,6 @@ snapshots:
   buffer-fill@1.0.0: {}
 
   buffer-from@1.1.2: {}
-
-  buffer-writer@2.0.0: {}
 
   buffer@5.7.1:
     dependencies:
@@ -22490,8 +22483,6 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.7.0
 
-  packet-reader@1.0.0: {}
-
   pacote@18.0.6:
     dependencies:
       "@npmcli/git": 5.0.8
@@ -22622,9 +22613,13 @@ snapshots:
 
   pg-numeric@1.0.2: {}
 
-  pg-pool@3.6.1(pg@8.11.3):
+  pg-pool@3.6.1(pg@8.14.1):
     dependencies:
-      pg: 8.11.3
+      pg: 8.14.1
+
+  pg-pool@3.8.0(pg@8.14.1):
+    dependencies:
+      pg: 8.14.1
 
   pg-protocol@1.8.0: {}
 
@@ -22646,12 +22641,10 @@ snapshots:
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
 
-  pg@8.11.3:
+  pg@8.14.1:
     dependencies:
-      buffer-writer: 2.0.0
-      packet-reader: 1.0.0
       pg-connection-string: 2.7.0
-      pg-pool: 3.6.1(pg@8.11.3)
+      pg-pool: 3.8.0(pg@8.14.1)
       pg-protocol: 1.8.0
       pg-types: 2.2.0
       pgpass: 1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ importers:
         specifier: 22.13.1
         version: 22.13.1
       "@types/pg":
-        specifier: ^8.11.4
-        version: 8.11.11
+        specifier: 8.11.4
+        version: 8.11.4
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
@@ -4491,10 +4491,10 @@ packages:
         integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
       }
 
-  "@types/pg@8.11.11":
+  "@types/pg@8.11.4":
     resolution:
       {
-        integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==
+        integrity: sha512-yw3Bwbda6vO+NvI1Ue/YKOwtl31AYvvd/e73O3V4ZkNzuGpTDndLSyc0dQRB2xrQqDePd20pEGIfqSp/GH3pRw==
       }
 
   "@types/prismjs@1.26.5":
@@ -18140,7 +18140,7 @@ snapshots:
 
   "@types/parse-json@4.0.2": {}
 
-  "@types/pg@8.11.11":
+  "@types/pg@8.11.4":
     dependencies:
       "@types/node": 22.13.1
       pg-protocol: 1.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,11 +258,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       pg:
-        specifier: ^8.11.3
-        version: 8.14.1
+        specifier: 8.11.3
+        version: 8.11.3
       pg-pool:
-        specifier: ^3.6.1
-        version: 3.8.0(pg@8.14.1)
+        specifier: 3.6.1
+        version: 3.6.1(pg@8.11.3)
     devDependencies:
       "@types/node":
         specifier: 22.13.1
@@ -5472,6 +5472,13 @@ packages:
       {
         integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
       }
+
+  buffer-writer@2.0.0:
+    resolution:
+      {
+        integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
+      }
+    engines: { node: ">=4" }
 
   buffer@5.7.1:
     resolution:
@@ -10871,6 +10878,12 @@ packages:
       }
     engines: { node: ">=14.16" }
 
+  packet-reader@1.0.0:
+    resolution:
+      {
+        integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+      }
+
   pacote@18.0.6:
     resolution:
       {
@@ -11081,10 +11094,10 @@ packages:
       }
     engines: { node: ">=4" }
 
-  pg-pool@3.8.0:
+  pg-pool@3.6.1:
     resolution:
       {
-        integrity: sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==
+        integrity: sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==
       }
     peerDependencies:
       pg: ">=8.0"
@@ -11109,10 +11122,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  pg@8.14.1:
+  pg@8.11.3:
     resolution:
       {
-        integrity: sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==
+        integrity: sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==
       }
     engines: { node: ">= 8.0.0" }
     peerDependencies:
@@ -18813,6 +18826,8 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer-writer@2.0.0: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -22475,6 +22490,8 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.7.0
 
+  packet-reader@1.0.0: {}
+
   pacote@18.0.6:
     dependencies:
       "@npmcli/git": 5.0.8
@@ -22605,9 +22622,9 @@ snapshots:
 
   pg-numeric@1.0.2: {}
 
-  pg-pool@3.8.0(pg@8.14.1):
+  pg-pool@3.6.1(pg@8.11.3):
     dependencies:
-      pg: 8.14.1
+      pg: 8.11.3
 
   pg-protocol@1.8.0: {}
 
@@ -22629,10 +22646,12 @@ snapshots:
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
 
-  pg@8.14.1:
+  pg@8.11.3:
     dependencies:
+      buffer-writer: 2.0.0
+      packet-reader: 1.0.0
       pg-connection-string: 2.7.0
-      pg-pool: 3.8.0(pg@8.14.1)
+      pg-pool: 3.6.1(pg@8.11.3)
       pg-protocol: 1.8.0
       pg-types: 2.2.0
       pgpass: 1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       "@maiar-ai/core":
         specifier: workspace:*
         version: link:../packages/core
+      "@maiar-ai/memory-postgres":
+        specifier: workspace:*
+        version: link:../packages/memory-postgres
       "@maiar-ai/memory-sqlite":
         specifier: workspace:*
         version: link:../packages/memory-sqlite
@@ -242,6 +245,31 @@ importers:
       "@types/node":
         specifier: 22.13.1
         version: 22.13.1
+      tsup:
+        specifier: 8.3.6
+        version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
+  packages/memory-postgres:
+    dependencies:
+      "@maiar-ai/core":
+        specifier: workspace:*
+        version: link:../core
+      pg:
+        specifier: ^8.11.3
+        version: 8.14.1
+      pg-pool:
+        specifier: ^3.6.1
+        version: 3.8.0(pg@8.14.1)
+    devDependencies:
+      "@types/node":
+        specifier: 22.13.1
+        version: 22.13.1
+      "@types/pg":
+        specifier: ^8.11.4
+        version: 8.11.11
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0)
@@ -4461,6 +4489,12 @@ packages:
     resolution:
       {
         integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
+      }
+
+  "@types/pg@8.11.11":
+    resolution:
+      {
+        integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==
       }
 
   "@types/prismjs@1.26.5":
@@ -11021,6 +11055,78 @@ packages:
       }
     engines: { node: ">=8" }
 
+  pg-cloudflare@1.1.1:
+    resolution:
+      {
+        integrity: sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==
+      }
+
+  pg-connection-string@2.7.0:
+    resolution:
+      {
+        integrity: sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==
+      }
+
+  pg-int8@1.0.1:
+    resolution:
+      {
+        integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+      }
+    engines: { node: ">=4.0.0" }
+
+  pg-numeric@1.0.2:
+    resolution:
+      {
+        integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==
+      }
+    engines: { node: ">=4" }
+
+  pg-pool@3.8.0:
+    resolution:
+      {
+        integrity: sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==
+      }
+    peerDependencies:
+      pg: ">=8.0"
+
+  pg-protocol@1.8.0:
+    resolution:
+      {
+        integrity: sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==
+      }
+
+  pg-types@2.2.0:
+    resolution:
+      {
+        integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+      }
+    engines: { node: ">=4" }
+
+  pg-types@4.0.2:
+    resolution:
+      {
+        integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==
+      }
+    engines: { node: ">=10" }
+
+  pg@8.14.1:
+    resolution:
+      {
+        integrity: sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==
+      }
+    engines: { node: ">= 8.0.0" }
+    peerDependencies:
+      pg-native: ">=3.0.1"
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution:
+      {
+        integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -11742,6 +11848,68 @@ packages:
         integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
       }
     engines: { node: ^10 || ^12 || >=14 }
+
+  postgres-array@2.0.0:
+    resolution:
+      {
+        integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+      }
+    engines: { node: ">=4" }
+
+  postgres-array@3.0.4:
+    resolution:
+      {
+        integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==
+      }
+    engines: { node: ">=12" }
+
+  postgres-bytea@1.0.0:
+    resolution:
+      {
+        integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
+      }
+    engines: { node: ">=0.10.0" }
+
+  postgres-bytea@3.0.0:
+    resolution:
+      {
+        integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==
+      }
+    engines: { node: ">= 6" }
+
+  postgres-date@1.0.7:
+    resolution:
+      {
+        integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+      }
+    engines: { node: ">=0.10.0" }
+
+  postgres-date@2.1.0:
+    resolution:
+      {
+        integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==
+      }
+    engines: { node: ">=12" }
+
+  postgres-interval@1.2.0:
+    resolution:
+      {
+        integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+      }
+    engines: { node: ">=0.10.0" }
+
+  postgres-interval@3.0.0:
+    resolution:
+      {
+        integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==
+      }
+    engines: { node: ">=12" }
+
+  postgres-range@1.1.4:
+    resolution:
+      {
+        integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==
+      }
 
   prebuild-install@7.1.3:
     resolution:
@@ -17959,6 +18127,12 @@ snapshots:
 
   "@types/parse-json@4.0.2": {}
 
+  "@types/pg@8.11.11":
+    dependencies:
+      "@types/node": 22.13.1
+      pg-protocol: 1.8.0
+      pg-types: 4.0.2
+
   "@types/prismjs@1.26.5": {}
 
   "@types/prop-types@15.7.14": {}
@@ -22422,6 +22596,53 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pg-cloudflare@1.1.1:
+    optional: true
+
+  pg-connection-string@2.7.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-numeric@1.0.2: {}
+
+  pg-pool@3.8.0(pg@8.14.1):
+    dependencies:
+      pg: 8.14.1
+
+  pg-protocol@1.8.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg-types@4.0.2:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+
+  pg@8.14.1:
+    dependencies:
+      pg-connection-string: 2.7.0
+      pg-pool: 3.8.0(pg@8.14.1)
+      pg-protocol: 1.8.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.1.1
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -22933,6 +23154,28 @@ snapshots:
       nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
+  postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
 
   prebuild-install@7.1.3:
     dependencies:


### PR DESCRIPTION
## Description
Adds a new memory provider `memory-postgres` so the agent can use a remote database like sup abase.

<img width="950" alt="image" src="https://github.com/user-attachments/assets/1fd7e192-bcc5-4c62-ae29-c9b6a4e0e5d1" />

## Changes Made
- [x] Feature added

## How to Test
Make a supabase db, add connection string to memory provider config, send message to agent with client

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
