### PR TITLE
feat: make monitor service a singleton

### DIFF
--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -1,5 +1,6 @@
 import { logModelInteraction } from "../utils/logger";
 import { ModelCapability } from "./capabilities";
+import { MonitorService } from "../monitor/service";
 
 /**
  * Configuration for model requests
@@ -73,6 +74,13 @@ export abstract class ModelProviderBase implements ModelProvider {
     this.name = name;
     this.description = description;
     this.capabilities = new Map();
+  }
+
+  /**
+   * Get access to the monitor service
+   */
+  protected get monitor() {
+    return MonitorService;
   }
 
   public addCapability(capability: ModelCapability): void {

--- a/packages/core/src/monitor/service.ts
+++ b/packages/core/src/monitor/service.ts
@@ -52,9 +52,9 @@ export class MonitorService {
   /**
    * Checks the health of all registered monitor providers.
    */
-  public static checkHealth(): Promise<void> {
+  public static async checkHealth(): Promise<void> {
     const instance = MonitorService.getInstance();
-    return Promise.all(
+    await Promise.all(
       instance.providers.map((provider) =>
         provider.checkHealth().catch((error: unknown) => {
           MonitorService.publishEvent({
@@ -67,6 +67,6 @@ export class MonitorService {
           });
         })
       )
-    ).then(() => {});
+    );
   }
 }

--- a/packages/core/src/monitor/service.ts
+++ b/packages/core/src/monitor/service.ts
@@ -3,7 +3,6 @@ import { MonitorProvider } from "./types";
 export interface MonitorEvent {
   type: string;
   message: string;
-  timestamp?: number;
   metadata?: Record<string, unknown>;
 }
 
@@ -42,7 +41,7 @@ export class MonitorService {
     const instance = MonitorService.getInstance();
     const eventWithTimestamp = {
       ...event,
-      timestamp: event.timestamp || Date.now()
+      timestamp: Date.now()
     };
 
     for (const provider of instance.providers) {
@@ -64,8 +63,7 @@ export class MonitorService {
             metadata: {
               providerId: provider.id,
               error: error instanceof Error ? error.message : String(error)
-            },
-            timestamp: Date.now()
+            }
           });
         })
       )

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -46,6 +46,18 @@ export function createRuntime(options: RuntimeOptions): Runtime {
 
   // Initialize the global monitor service with providers
   MonitorService.init(options.monitor || []);
+
+  MonitorService.checkHealth()
+    .then(() => {
+      MonitorService.publishEvent({
+        type: "monitor.healthcheck.passed",
+        message: "Monitor service healthcheck passed"
+      });
+    })
+    .catch((error) => {
+      log.error("Monitor service healthcheck failed", error);
+    });
+
   const monitorService = MonitorService.getInstance();
 
   const memoryService = new MemoryService(options.memory);

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -374,8 +374,7 @@ export class Runtime {
       message: "Runtime initialized",
       metadata: {
         plugins: this.plugins.map((p) => p.id)
-      },
-      timestamp: Date.now()
+      }
     });
   }
 
@@ -475,8 +474,7 @@ export class Runtime {
       message: "Runtime started",
       metadata: {
         plugins: this.registry.getAllPlugins().map((p) => p.id)
-      },
-      timestamp: Date.now()
+      }
     });
 
     this.runEvaluationLoop().catch((error) => {
@@ -498,8 +496,7 @@ export class Runtime {
     // Log stop event
     MonitorService.publishEvent({
       type: "runtime.stop",
-      message: "Runtime stopped",
-      timestamp: Date.now()
+      message: "Runtime stopped"
     });
   }
 
@@ -641,8 +638,7 @@ export class Runtime {
           message: `Runtime error occurred`,
           metadata: {
             error: error instanceof Error ? error.message : String(error)
-          },
-          timestamp: Date.now()
+          }
         });
         throw error;
       } finally {
@@ -711,8 +707,7 @@ export class Runtime {
           platform,
           message,
           template
-        },
-        timestamp: Date.now()
+        }
       });
 
       log.debug({
@@ -744,8 +739,7 @@ export class Runtime {
           template,
           pipeline,
           steps
-        },
-        timestamp: Date.now()
+        }
       });
 
       log.info({
@@ -770,8 +764,7 @@ export class Runtime {
                 }
               : error,
           template: generatePipelineTemplate(pipelineContext)
-        },
-        timestamp: Date.now()
+        }
       });
 
       log.error({
@@ -990,8 +983,7 @@ export class Runtime {
                 currentStep,
                 modifiedSteps: modification.modifiedSteps,
                 pipeline: currentPipeline
-              },
-              timestamp: Date.now()
+              }
             });
           }
         } catch (error) {
@@ -1050,8 +1042,7 @@ export class Runtime {
           isRunning: this.isRunning,
           lastUpdate: Date.now()
         }
-      },
-      timestamp: Date.now()
+      }
     });
   }
 

--- a/packages/model-openai/src/openai.ts
+++ b/packages/model-openai/src/openai.ts
@@ -92,8 +92,7 @@ export class OpenAIProvider extends ModelProviderBase {
           capability: "text-generation",
           input: textGenerationSchema.input,
           output: textGenerationSchema.output
-        },
-        timestamp: Date.now()
+        }
       });
     }
 
@@ -166,8 +165,7 @@ export class OpenAIProvider extends ModelProviderBase {
           capabilityId: "text-generation",
           input: prompt,
           output: content
-        },
-        timestamp: Date.now()
+        }
       });
 
       return content;
@@ -180,8 +178,7 @@ export class OpenAIProvider extends ModelProviderBase {
           modelId: this.id,
           capabilityId: "text-generation",
           error: error instanceof Error ? error.message : String(error)
-        },
-        timestamp: Date.now()
+        }
       });
       throw error;
     }
@@ -208,8 +205,7 @@ export class OpenAIProvider extends ModelProviderBase {
         metadata: {
           model: this.id,
           response: resp
-        },
-        timestamp: Date.now()
+        }
       });
     } catch (error) {
       MonitorService.publishEvent({
@@ -218,8 +214,7 @@ export class OpenAIProvider extends ModelProviderBase {
         metadata: {
           model: this.id,
           error: error instanceof Error ? error.message : String(error)
-        },
-        timestamp: Date.now()
+        }
       });
       throw new Error(
         `Failed to initialize Model ${this.id}: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/plugin-x/src/plugin.ts
+++ b/packages/plugin-x/src/plugin.ts
@@ -2,7 +2,8 @@ import {
   PluginBase,
   ExecutorImplementation,
   Trigger,
-  Runtime
+  Runtime,
+  MonitorService
 } from "@maiar-ai/core";
 import {
   XPluginConfig,
@@ -54,7 +55,7 @@ export class PluginX extends PluginBase {
     await super.init(runtime);
 
     // This log confirms that we're being initialized with a valid runtime
-    runtime.monitor.publishEvent({
+    MonitorService.publishEvent({
       type: "plugin-x",
       message: "plugin x initalizing..."
     });
@@ -89,18 +90,18 @@ export class PluginX extends PluginBase {
     }
 
     if (!this.isAuthenticated) {
-      this.runtime.monitor.publishEvent({
+      MonitorService.publishEvent({
         type: "plugin-x",
         message: "🔐 X API Authentication Required"
       });
-      this.runtime.monitor.publishEvent({
+      MonitorService.publishEvent({
         type: "plugin-x",
         message:
           "No valid authentication token found. Starting authentication flow..."
       });
 
       // Automatically run the authentication flow
-      this.runtime.monitor.publishEvent({
+      MonitorService.publishEvent({
         type: "plugin-x",
         message:
           "You can also manually run authentication at any time with: pnpm maiar-x-login"
@@ -111,7 +112,7 @@ export class PluginX extends PluginBase {
         const success = await this.runAuthentication();
 
         if (success) {
-          this.runtime.monitor.publishEvent({
+          MonitorService.publishEvent({
             type: "plugin-x",
             message: "Plugin X authenticated successfully"
           });
@@ -119,7 +120,7 @@ export class PluginX extends PluginBase {
           console.error(
             "❌ X Plugin authentication failed. Plugin functionality will be limited."
           );
-          this.runtime.monitor.publishEvent({
+          MonitorService.publishEvent({
             type: "plugin-x",
             message: "❌ X Plugin authentication failed."
           });
@@ -128,14 +129,14 @@ export class PluginX extends PluginBase {
         console.error("❌ X Plugin authentication error:", error);
         console.error("You can attempt manual authentication with:");
         console.error("pnpm maiar-x-login\n");
-        this.runtime.monitor.publishEvent({
+        MonitorService.publishEvent({
           type: "plugin-x",
           message: `❌ Plugin X authentication error: ${error}. You can attempt manual authentication with: pnpm maiar-x-login`
         });
         throw error;
       }
     } else {
-      this.runtime.monitor.publishEvent({
+      MonitorService.publishEvent({
         type: "plugin-x",
         message: "Plugin X authenticated successfully"
       });
@@ -144,7 +145,7 @@ export class PluginX extends PluginBase {
     // Register executors and triggers now that we have a runtime
     this.registerExecutorsAndTriggers();
 
-    runtime.monitor.publishEvent({
+    MonitorService.publishEvent({
       type: "plugin-x",
       message: "Plugin X initialized."
     });
@@ -155,7 +156,7 @@ export class PluginX extends PluginBase {
    * This is separated from init for clarity and is only called after runtime is available
    */
   private registerExecutorsAndTriggers(): void {
-    this.runtime.monitor.publishEvent({
+    MonitorService.publishEvent({
       type: "plugin-x",
       message: "Registering X plugin executors and triggers"
     });
@@ -219,7 +220,7 @@ export class PluginX extends PluginBase {
       }
     }
 
-    this.runtime.monitor.publishEvent({
+    MonitorService.publishEvent({
       type: "plugin-x",
       message: `Registered ${this.executors.length} executors and ${this.triggers.length} triggers`
     });

--- a/packages/plugin-x/src/triggers.ts
+++ b/packages/plugin-x/src/triggers.ts
@@ -125,8 +125,7 @@ export const periodicPostTrigger = createXTrigger(
             const recoveryMs = (30 + Math.random() * 30) * 60 * 1000;
             MonitorService.publishEvent({
               type: "plugin-x",
-              message: `Scheduling recovery attempt in ${Math.round(recoveryMs / 1000 / 60)} minutes`,
-              timestamp: Date.now()
+              message: `Scheduling recovery attempt in ${Math.round(recoveryMs / 1000 / 60)} minutes`
             });
             setTimeout(scheduleNextPost, recoveryMs);
           }


### PR DESCRIPTION
## Description
Rather than attaching the monitors to the runtime and passing them around as a property of the runtime, make them a singleton object instead so that monitors can be used anywhere in the codebase: model providers, memory providers, plugins, or core runtime code

## Related Issues
NA

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test
run maiar-starter and maiar-client, observe model lifecycle events in the event view.

## Checklist

- [ ] Code follows project style guidelines
- [ ] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [ ] Ready for review 🚀
