### PR TITLE
feat(core): extending memory operations with plugin

### DIFF
--- a/maiar-starter/package.json
+++ b/maiar-starter/package.json
@@ -12,8 +12,9 @@
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",
-    "@maiar-ai/memory-sqlite": "workspace:*",
+    "@maiar-ai/memory-filesystem": "workspace:*",
     "@maiar-ai/memory-postgres": "workspace:*",
+    "@maiar-ai/memory-sqlite": "workspace:*",
     "@maiar-ai/model-openai": "workspace:*",
     "@maiar-ai/monitor-console": "workspace:*",
     "@maiar-ai/monitor-websocket": "workspace:*",

--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -13,9 +13,6 @@ import {
   OpenAITextGenerationModel
 } from "@maiar-ai/model-openai";
 
-// Import memory provider
-import { PostgresProvider } from "@maiar-ai/memory-postgres";
-
 // Import monitor providers
 import { ConsoleMonitorProvider } from "@maiar-ai/monitor-console";
 import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
@@ -45,6 +42,9 @@ process.removeAllListeners("warning");
 config({
   path: path.resolve(__dirname, "../../..", ".env")
 });
+import { PostgresProvider } from "@maiar-ai/memory-postgres";
+// import { FileSystemProvider } from "@maiar-ai/memory-filesystem";
+// import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
 
 // Create and start the agent
 const runtime = createRuntime({
@@ -60,6 +60,12 @@ const runtime = createRuntime({
   memory: new PostgresProvider({
     connectionString: process.env.DATABASE_URL as string
   }),
+  // memory: new SQLiteProvider({
+  //   dbPath: path.join(process.cwd(), "data", "conversations.db")
+  // }),
+  // memory: new FileSystemProvider({
+  //   basePath: path.join(process.cwd(), "data")
+  // }),
   monitor: [
     new ConsoleMonitorProvider(),
     new WebSocketMonitorProvider({

--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -13,6 +13,9 @@ import {
   OpenAITextGenerationModel
 } from "@maiar-ai/model-openai";
 
+// Import memory provider
+import { PostgresProvider } from "@maiar-ai/memory-postgres";
+
 // Import monitor providers
 import { ConsoleMonitorProvider } from "@maiar-ai/monitor-console";
 import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
@@ -42,9 +45,6 @@ process.removeAllListeners("warning");
 config({
   path: path.resolve(__dirname, "../../..", ".env")
 });
-import { PostgresProvider } from "@maiar-ai/memory-postgres";
-// import { FileSystemProvider } from "@maiar-ai/memory-filesystem";
-// import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
 
 // Create and start the agent
 const runtime = createRuntime({
@@ -60,12 +60,6 @@ const runtime = createRuntime({
   memory: new PostgresProvider({
     connectionString: process.env.DATABASE_URL as string
   }),
-  // memory: new SQLiteProvider({
-  //   dbPath: path.join(process.cwd(), "data", "conversations.db")
-  // }),
-  // memory: new FileSystemProvider({
-  //   basePath: path.join(process.cwd(), "data")
-  // }),
   monitor: [
     new ConsoleMonitorProvider(),
     new WebSocketMonitorProvider({

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1,3 +1,5 @@
+import { Plugin } from "../plugin";
+
 export interface Message {
   id: string;
   role: string;
@@ -37,6 +39,9 @@ export interface MemoryProvider {
   readonly id: string;
   readonly name: string;
   readonly description: string;
+
+  // Get memory plugin
+  getPlugin(): Plugin;
 
   // Store a new message
   storeMessage(message: Message, conversationId: string): Promise<void>;

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -614,8 +614,16 @@ export class Runtime {
     initialContext: UserInputContext,
     platformContext?: AgentContext["platformContext"]
   ): Promise<void> {
+    // Get conversationId from memory service
+    const conversationId = await this.memoryService.getOrCreateConversation(
+      initialContext.user,
+      initialContext.pluginId
+    );
+
+    // Add conversationId to platform context metadata
     const context: AgentContext = {
       contextChain: [initialContext],
+      conversationId,
       platformContext,
       eventQueue: this.queueInterface
     };

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -71,7 +71,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     modelService,
     monitorService,
     memoryService,
-    plugins: options.plugins
+    plugins: [options.memory.getPlugin(), ...options.plugins]
   });
 
   for (const model of options.models) {

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -40,6 +40,7 @@ export interface EventQueue {
 // The full context chain container
 export interface AgentContext {
   contextChain: BaseContextItem[];
+  conversationId?: string;
   eventQueue?: EventQueue;
   platformContext?: {
     platform: string;

--- a/packages/memory-filesystem/package.json
+++ b/packages/memory-filesystem/package.json
@@ -46,7 +46,8 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@maiar-ai/core": "workspace:*"
+    "@maiar-ai/core": "workspace:*",
+    "zod": "3.24.1"
   },
   "devDependencies": {
     "@types/node": "22.13.1",

--- a/packages/memory-filesystem/src/plugin.ts
+++ b/packages/memory-filesystem/src/plugin.ts
@@ -1,0 +1,87 @@
+import path from "path";
+import fs from "fs";
+import fsPromises from "fs/promises";
+
+import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
+import { FileSystemConfig } from "./types";
+
+export class FileSystemMemoryPlugin extends PluginBase {
+  private sandboxPath: string;
+
+  constructor(config: FileSystemConfig) {
+    super({
+      id: "plugin-filesystem-memory",
+      name: "File System Memory Plugin",
+      description:
+        "Memory extension that allows for runtime operations to control a sandbox table"
+    });
+    this.sandboxPath = path.join(config.basePath, "sandbox.json");
+
+    this.addExecutor({
+      name: "memory:add_document",
+      description:
+        "Add a peice of context from the context chain into the sandboxed database",
+      execute: async (context: AgentContext): Promise<PluginResult> => {
+        const timestamp = Date.now();
+        const documentId = `doc_${timestamp}`;
+
+        // Add most recent peice of context to the sandbox database
+        const contextItem =
+          context.contextChain[context.contextChain.length - 1];
+
+        // Get the latest conversation ID by finding the most recent conversation file
+        let conversationId: string | null = null;
+
+        try {
+          // Get the directory containing conversation files
+          const baseDir = path.dirname(this.sandboxPath);
+
+          // Read all files in the directory
+          const files = fs.readdirSync(baseDir);
+
+          // Filter for JSON files that aren't sandbox.json
+          const conversationFiles = files
+            .filter((file) => file.endsWith(".json") && file !== "sandbox.json")
+            .map((file) => ({
+              name: file,
+              path: path.join(baseDir, file),
+              stats: fs.statSync(path.join(baseDir, file))
+            }));
+
+          // Sort by modification time (most recent first)
+          conversationFiles.sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs);
+
+          // Get the most recent conversation ID (filename without extension)
+          if (conversationFiles.length > 0) {
+            conversationId = path.basename(conversationFiles[0].name, ".json");
+          }
+        } catch (error) {
+          console.error("Error finding latest conversation:", error);
+        }
+
+        if (!conversationId) {
+          return {
+            success: false,
+            error: "No conversation found"
+          };
+        }
+
+        await fsPromises.writeFile(
+          this.sandboxPath,
+          JSON.stringify(
+            {
+              id: documentId,
+              conversation_id: conversationId,
+              content: contextItem?.content,
+              timestamp: timestamp
+            },
+            null,
+            2
+          )
+        );
+
+        return { success: true, data: { documentId } };
+      }
+    });
+  }
+}

--- a/packages/memory-filesystem/src/plugin.ts
+++ b/packages/memory-filesystem/src/plugin.ts
@@ -72,12 +72,27 @@ export class FileSystemMemoryPlugin extends PluginBase {
         }
 
         try {
-          const existingContent = await fsPromises.readFile(
-            this.sandboxPath,
-            "utf-8"
-          );
-          const existingData = JSON.parse(existingContent);
-          const documents = existingData.documents || [];
+          let documents = [];
+          try {
+            const existingContent = await fsPromises.readFile(
+              this.sandboxPath,
+              "utf-8"
+            );
+            const existingData = JSON.parse(existingContent);
+            documents = existingData.documents || [];
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              "code" in error &&
+              error.code !== "ENOENT"
+            ) {
+              throw new Error(
+                `An unexpected error occured when trying to add document to database: ${error.message}`
+              );
+            }
+            // Only initialize empty documents array for file not found errors
+            documents = [];
+          }
 
           // Add new document
           documents.push({

--- a/packages/memory-filesystem/src/provider.ts
+++ b/packages/memory-filesystem/src/provider.ts
@@ -3,16 +3,15 @@ import path from "path";
 
 import { MonitorService } from "@maiar-ai/core";
 import {
+  MemoryProvider,
+  Message,
   Context,
   Conversation,
-  MemoryProvider,
   MemoryQueryOptions,
-  Message
+  Plugin
 } from "@maiar-ai/core";
-
-export interface FileSystemConfig {
-  basePath: string;
-}
+import { FileSystemConfig } from "./types";
+import { FileSystemMemoryPlugin } from "./plugin";
 
 export class FileSystemProvider implements MemoryProvider {
   readonly id = "filesystem";
@@ -20,10 +19,12 @@ export class FileSystemProvider implements MemoryProvider {
   readonly description = "Stores conversations as JSON files in the filesystem";
 
   private basePath: string;
+  private plugin: FileSystemMemoryPlugin;
 
   constructor(config: FileSystemConfig) {
     this.basePath = config.basePath;
     this.initializeStorage();
+    this.plugin = new FileSystemMemoryPlugin(config);
   }
 
   private async initializeStorage() {
@@ -51,6 +52,10 @@ export class FileSystemProvider implements MemoryProvider {
 
   private getConversationPath(conversationId: string): string {
     return path.join(this.basePath, `${conversationId}.json`);
+  }
+
+  public getPlugin(): Plugin {
+    return this.plugin;
   }
 
   async createConversation(options?: {

--- a/packages/memory-filesystem/src/templates.ts
+++ b/packages/memory-filesystem/src/templates.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-useless-escape */
 import { BaseContextItem } from "@maiar-ai/core";
 
-export function generateUploadDocumnetTemplate(
+export function generateUploadDocumentTemplate(
   contextChain: BaseContextItem[]
 ): string {
   return `Generate a response based on the context chain. Your response shoudl be a JSON object with a single "content" field containing your response.

--- a/packages/memory-filesystem/src/templates.ts
+++ b/packages/memory-filesystem/src/templates.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-useless-escape */
+import { BaseContextItem } from "@maiar-ai/core";
+
+export function generateUploadDocumnetTemplate(
+  contextChain: BaseContextItem[]
+): string {
+  return `Generate a response based on the context chain. Your response shoudl be a JSON object with a single "content" field containing your response.
+        The response should be the exact text that should be uploaded to the sandbox database for later use.
+
+        IMPORTANT: Your response MUST be valid JSON:
+        - Use double quotes (") not single quotes (')
+        - Escape any quotes within strings with backslash (\")
+        - Do not use smart/curly quotes
+        - The response must be parseable by JSON.parse()
+
+        Do NOT include any metadata, context information, or explanation of how the response was generated.
+        Look for the relevant information in the most recent context items (e.g. generated text, current time, etc).
+
+        Here is the Context Chain, it contains all messages from the user and plugin response. Your job is to find the content
+        that the user or plugin wants to upload to the database for future use and generate a response with just that information.
+        Make sure to keep the content exactly how it was presented by the user or plugin.
+        ${JSON.stringify(contextChain, null, 2)}
+
+        Example of a valid response:
+        {
+            "content": "This is example text to upload to the database"
+        }
+    `;
+}
+
+export function generateQueryTemplate(contextChain: BaseContextItem[]): string {
+  return `Generate a response based on the context chain. Your response should be a JSON object with fields corresponding to the fields
+        in the database to filter with. The response will be used to search a JSON file database, so your response should be 
+        only those property values that can be used to filter the database.
+        The available fields are:
+        - id
+        - conversationId
+        - content
+        - timestamp
+
+        You only need to respond with non-null fields, if you cannot construct fields to query with return an empty object.
+
+        IMPORTANT: Your response MUST be valid JSON:
+        - Use double quotes (") not single quotes (')
+        - Escape any quotes within strings with backslash (\")
+        - Do not use smart/curly quotes
+        - The response must be parseable by JSON.parse()
+
+        Do NOT include any metadata, context information, or explanation of how the response was generated.
+        Look for the relevant information in the most recent context items (e.g. generated text, current time, etc).
+
+        Here is the context chain, it contains all messages from the user and plugin responses. Your job is to construct
+        the values for each available field that will then be used to filter the JSON database file.
+        ${JSON.stringify(contextChain, null, 2)}
+
+        Example of a valid response that filters the database by content that contains the word "test":
+        {
+            "content": "test",
+        }
+
+        Example of a valid response that filters the database by ids that contain "doc":
+        {
+            "id": "doc",
+        }
+    `;
+}

--- a/packages/memory-filesystem/src/types.ts
+++ b/packages/memory-filesystem/src/types.ts
@@ -1,3 +1,41 @@
+import { z } from "zod";
+
 export interface FileSystemConfig {
   basePath: string;
 }
+
+export interface FileSystemMemoryDocument {
+  id: string;
+  conversationId: string;
+  content: string;
+  timestamp: number;
+}
+
+export const FileSystemMemoryUploadSchema = z.object({
+  content: z.string().describe("Data to upload to the sandbox database")
+});
+
+export interface FileSystemQuery {
+  ids?: string[];
+  conversationIds?: string[];
+  content?: string;
+  before?: number;
+  after?: number;
+}
+
+export const FileSystemQuerySchema = z.object({
+  ids: z
+    .array(z.string())
+    .optional()
+    .describe("Array of document IDs to query"),
+  conversationIds: z
+    .array(z.string())
+    .optional()
+    .describe("Conversation IDs of documents to query"),
+  content: z.string().optional().describe("Content to search documents for"),
+  before: z
+    .number()
+    .optional()
+    .describe("Timestamp to filter documnets before"),
+  after: z.number().optional().describe("Timestamp to filter documents after")
+});

--- a/packages/memory-filesystem/src/types.ts
+++ b/packages/memory-filesystem/src/types.ts
@@ -1,0 +1,3 @@
+export interface FileSystemConfig {
+  basePath: string;
+}

--- a/packages/memory-postgres/package.json
+++ b/packages/memory-postgres/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "@maiar-ai/core": "workspace:*",
     "pg": "8.14.1",
-    "pg-pool": "3.6.1"
+    "pg-pool": "3.6.1",
+    "zod": "3.24.1"
   },
   "devDependencies": {
     "@types/node": "22.13.1",

--- a/packages/memory-postgres/src/database.ts
+++ b/packages/memory-postgres/src/database.ts
@@ -1,0 +1,42 @@
+import { Pool } from "pg";
+import { PostgresConfig } from "./types";
+
+export class PostgresDatabase {
+  private static instance: PostgresDatabase;
+  private pool: Pool | null = null;
+
+  private constructor() {}
+
+  public init(config: PostgresConfig) {
+    if (!this.pool) {
+      this.pool = new Pool({
+        connectionString: config.connectionString,
+        ssl: config.ssl,
+        max: config.max || 20
+      });
+    }
+  }
+
+  public static getInstance(): PostgresDatabase {
+    if (!PostgresDatabase.instance) {
+      PostgresDatabase.instance = new PostgresDatabase();
+    }
+    return PostgresDatabase.instance;
+  }
+
+  public getPool(): Pool {
+    if (!this.pool) {
+      throw new Error(
+        "Pool not initialized, Call .init() on PostgresDatabase before accessing pool"
+      );
+    }
+    return this.pool!;
+  }
+
+  public async close(): Promise<void> {
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+    }
+  }
+}

--- a/packages/memory-postgres/src/plugin.ts
+++ b/packages/memory-postgres/src/plugin.ts
@@ -1,0 +1,77 @@
+import { Pool } from "pg";
+import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
+import { PostgresDatabase } from "./database";
+
+export class PostgressMemoryPlugin extends PluginBase {
+  private pool: Pool;
+
+  constructor() {
+    super({
+      id: "plugin-postgres-memory",
+      name: "Postgres Memory Plugin",
+      description:
+        "Memory extension that allows for runtime operations to control a sandbox table"
+    });
+    this.pool = PostgresDatabase.getInstance().getPool();
+    this.createTable();
+
+    this.addExecutor({
+      name: "memory:add_document",
+      description:
+        "Add a peice of context from the context chain into the sandboxed database",
+      execute: async (context: AgentContext): Promise<PluginResult> => {
+        const timestamp = Date.now();
+        const documentId = `doc_${timestamp}_${Math.random().toString(36).substr(2, 9)}`;
+
+        // Add most recent peice of context to the sandbox database
+        const contextItem =
+          context.contextChain[context.contextChain.length - 1];
+
+        const client = await this.pool.connect();
+        try {
+          // Query to get the most recent conversation ID from the conversations table
+          const conversationResult = await client.query(`
+                    SELECT id FROM conversations 
+                    ORDER BY created_at DESC 
+                    LIMIT 1
+                  `);
+
+          if (conversationResult.rows.length === 0) {
+            throw new Error("No conversations found in the database");
+          }
+
+          const conversationId = conversationResult.rows[0].id;
+          await client.query(
+            `INSERT INTO messages (id, conversation_id, role, content, timestamp, context_id, user_message_id)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            [documentId, conversationId, contextItem?.content, timestamp]
+          );
+        } finally {
+          client.release();
+        }
+
+        return {
+          success: true,
+          data: { documentId }
+        };
+      }
+    });
+  }
+
+  async createTable(): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(`
+              CREATE TABLE IF NOT EXISTS sandbox (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                content TEXT NOT NULL,
+                timestamp BIGINT NOT NULL,
+                FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+              );
+            `);
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/packages/memory-postgres/src/provider.ts
+++ b/packages/memory-postgres/src/provider.ts
@@ -11,7 +11,7 @@ import {
 
 import { PostgresConfig } from "./types";
 import { PostgresDatabase } from "./database";
-import { PostgressMemoryPlugin } from "./plugin";
+import { PostgresMemoryPlugin } from "./plugin";
 
 type JSONValue =
   | string
@@ -27,7 +27,7 @@ export class PostgresProvider implements MemoryProvider {
   readonly description = "Stores conversations in a PostgreSQL database";
 
   private pool: Pool;
-  private plugin: PostgressMemoryPlugin;
+  private plugin: PostgresMemoryPlugin;
 
   constructor(config: PostgresConfig) {
     const poolInstance = PostgresDatabase.getInstance();
@@ -36,7 +36,7 @@ export class PostgresProvider implements MemoryProvider {
     this.pool = poolInstance.getPool();
     this.initializeStorage();
     this.checkHealth();
-    this.plugin = new PostgressMemoryPlugin();
+    this.plugin = new PostgresMemoryPlugin();
   }
 
   private async checkHealth() {

--- a/packages/memory-postgres/src/templates.ts
+++ b/packages/memory-postgres/src/templates.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-useless-escape */
 import { BaseContextItem } from "@maiar-ai/core";
 
-export function generateUploadDocumnetTemplate(
+export function generateUploadDocumentTemplate(
   contextChain: BaseContextItem[]
 ): string {
   return `Generate a response based on the context chain. Your response shoudl be a JSON object with a single "content" field containing your response.

--- a/packages/memory-postgres/src/templates.ts
+++ b/packages/memory-postgres/src/templates.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-useless-escape */
+import { BaseContextItem } from "@maiar-ai/core";
+
+export function generateUploadDocumnetTemplate(
+  contextChain: BaseContextItem[]
+): string {
+  return `Generate a response based on the context chain. Your response shoudl be a JSON object with a single "content" field containing your response.
+        The response should be the exact text that should be uploaded to the sandbox database for later use.
+
+        IMPORTANT: Your response MUST be valid JSON:
+        - Use double quotes (") not single quotes (')
+        - Escape any quotes within strings with backslash (\")
+        - Do not use smart/curly quotes
+        - The response must be parseable by JSON.parse()
+
+        Do NOT include any metadata, context information, or explanation of how the response was generated.
+        Look for the relevant information in the most recent context items (e.g. generated text, current time, etc).
+
+        Here is the Context Chain, it contains all messages from the user and plugin response. Your job is to find the content
+        that the user or plugin wants to upload to the database for future use and generate a response with just that information.
+        Make sure to keep the content exactly how it was presented by the user or plugin.
+        ${JSON.stringify(contextChain, null, 2)}
+
+        Example of a valid response:
+        {
+            "content": "This is example text to upload to the database"
+        }
+    `;
+}
+
+export function generateQueryTemplate(
+  contextChain: BaseContextItem[],
+  properties: string[] | string = "id"
+): string {
+  return `Generate a response based on the context chain. Your response should be a JSON object with a single "query" field containing a valid SQL query.
+        The query should be a search on the sandbox table that returns document values ${properties}.
+
+        IMPORTANT: Your response MUST be valid JSON:
+        - Use double quotes (") not single quotes (')
+        - Escape any quotes within strings with backslash (\")
+        - Do not use smart/curly quotes
+        - The response must be parseable by JSON.parse()
+
+        Do NOT include any metadata, context information, or explanation of how the response was generated.
+        Look for the relevant information in the most recent context items (e.g. generated text, current time, etc).
+
+        Here is the context chain, it contains all messages from the user and plugin responses. Your job is to construct
+        a query on the sandbox table that satisifes the users or plugins request outlined in the context chain.
+        Make sure to only respond with the documnet ids that match the query.
+        ${JSON.stringify(contextChain, null, 2)}
+
+        Example of a valid response:
+        {
+            "query": "SELECT id FROM sandbox WHERE content == 'This is the content of a test document'"
+        }
+    `;
+}

--- a/packages/memory-postgres/src/types.ts
+++ b/packages/memory-postgres/src/types.ts
@@ -1,5 +1,15 @@
+import { z } from "zod";
+
 export interface PostgresConfig {
   connectionString: string;
   ssl?: boolean;
   max?: number; // maximum number of clients in pool
 }
+
+export const PostgresMemoryUploadSchema = z.object({
+  content: z.string().describe("Data to upload to the sandbox database")
+});
+
+export const PostgresQuerySchema = z.object({
+  query: z.string().describe("Postgresql query string")
+});

--- a/packages/memory-postgres/src/types.ts
+++ b/packages/memory-postgres/src/types.ts
@@ -1,0 +1,5 @@
+export interface PostgresConfig {
+  connectionString: string;
+  ssl?: boolean;
+  max?: number; // maximum number of clients in pool
+}

--- a/packages/memory-sqlite/package.json
+++ b/packages/memory-sqlite/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@maiar-ai/core": "workspace:*",
-    "better-sqlite3": "11.8.1"
+    "better-sqlite3": "11.8.1",
+    "zod": "3.24.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.12",

--- a/packages/memory-sqlite/src/database.ts
+++ b/packages/memory-sqlite/src/database.ts
@@ -1,0 +1,38 @@
+import path from "path";
+import Database from "better-sqlite3";
+
+import { SQLiteConfig } from "./types";
+
+export class SQLiteDatabase {
+  private static instance: SQLiteDatabase;
+  private db: Database.Database | null = null;
+
+  private constructor() {}
+
+  public init(config: SQLiteConfig): void {
+    if (!this.db) {
+      this.db = new Database(path.resolve(config.dbPath));
+    }
+  }
+
+  public static getInstance(): SQLiteDatabase {
+    if (!SQLiteDatabase.instance) {
+      SQLiteDatabase.instance = new SQLiteDatabase();
+    }
+    return SQLiteDatabase.instance;
+  }
+
+  public getDatabase(): Database.Database {
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+    return this.db;
+  }
+
+  public close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+}

--- a/packages/memory-sqlite/src/plugin.ts
+++ b/packages/memory-sqlite/src/plugin.ts
@@ -1,7 +1,12 @@
-import Database from "better-sqlite3";
+import Database, { Statement } from "better-sqlite3";
 
 import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
 import { SQLiteDatabase } from "./database";
+import { SQLiteMemoryUploadSchema, SQLiteQuerySchema } from "./types";
+import {
+  generateUploadDocumnetTemplate,
+  generateQueryTemplate
+} from "./templates";
 
 export class SQLiteMemoryPlugin extends PluginBase {
   private db: Database.Database;
@@ -21,8 +26,7 @@ export class SQLiteMemoryPlugin extends PluginBase {
                     id TEXT PRIMARY KEY,
                     conversation_id TEXT NOT NULL,
                     content TEXT NOT NULL,
-                    timestamp INTEGER NOT NULL,
-                    plugin_id TEXT,
+                    timestamp BIGINT NOT NULL,
                     FOREIGN KEY (conversation_id) REFERENCES conversations(id)
                 )
         `);
@@ -32,37 +36,118 @@ export class SQLiteMemoryPlugin extends PluginBase {
       description: "Add a peice of information into the sandboxed database",
       execute: async (context: AgentContext): Promise<PluginResult> => {
         const stmt = this.db.prepare(`
-                    INSERT INTO sandbox (id, conversation_id, content, timestamp, plugin_id)
-                    VALUES (?, ?, ?, ?, ?)
-                `);
+            INSERT INTO sandbox (id, conversation_id, content, timestamp)
+            VALUES (?, ?, ?, ?)
+        `);
 
         const timestamp = Date.now();
         const documentId = `doc_${timestamp}_${Math.random().toString(36).substr(2, 9)}`;
 
-        // Add most recent peice of context to the sandbox database
-        const contextItem =
-          context.contextChain[context.contextChain.length - 1];
+        // Get data to store in database from context chain
+        const formattedResponse = await this.runtime.operations.getObject(
+          SQLiteMemoryUploadSchema,
+          generateUploadDocumnetTemplate(context.contextChain),
+          { temperature: 0.2 }
+        );
 
         // Query to get the most recent conversation ID from the conversations table
         const getLatestConversationStmt = this.db.prepare(`
-                    SELECT id FROM conversations 
-                    ORDER BY timestamp DESC 
-                    LIMIT 1
-                `);
+            SELECT id FROM conversations 
+            ORDER BY created_at DESC 
+            LIMIT 1
+        `);
 
-        const latestConversation = getLatestConversationStmt.get();
+        const latestConversation = getLatestConversationStmt.get() as {
+          id: string;
+        };
+        if (!latestConversation.id) {
+          throw new Error("No conversations found");
+        }
 
         stmt.run(
           documentId,
-          latestConversation,
-          contextItem?.content,
-          timestamp,
-          this.id
+          latestConversation.id,
+          formattedResponse.content,
+          timestamp
         );
 
         return {
           success: true,
           data: { documentId }
+        };
+      }
+    });
+
+    this.addExecutor({
+      name: "memory:remove_document",
+      description: "Remove a peice of information from the sandbox database",
+      execute: async (context: AgentContext): Promise<PluginResult> => {
+        // Construct query for document ids
+        const queryFormattedResponse = await this.runtime.operations.getObject(
+          SQLiteQuerySchema,
+          generateQueryTemplate(context.contextChain),
+          { temperature: 0.2 }
+        );
+        const queryStmt = this.db.prepare(queryFormattedResponse.query);
+        const queryResults = queryStmt.all() as { id: string }[];
+
+        if (queryResults.length === 0) {
+          return {
+            success: false,
+            data: {
+              message: `No documnets found with query: ${queryFormattedResponse.query}`
+            }
+          };
+        }
+
+        let deleteStmt: Statement;
+        const documentIds = queryResults.map((result) => result.id).join(", ");
+        if (queryResults.length === 1) {
+          deleteStmt = this.db.prepare(`
+            DELETE FROM sandbox
+            WHERE id = '${queryResults[0]?.id}'
+          `);
+        } else {
+          deleteStmt = this.db.prepare(`
+              DELETE FROM sandbox 
+              WHERE id IN (${documentIds})
+          `);
+        }
+
+        const result = deleteStmt.run();
+        if (result.changes === 0) {
+          return {
+            success: false,
+            data: {
+              message: `Database was not altered, check query. ${queryFormattedResponse.query}. Found documents ids ${documentIds}`
+            }
+          };
+        }
+
+        return {
+          success: true,
+          data: { documentIds }
+        };
+      }
+    });
+
+    this.addExecutor({
+      name: "memory:query",
+      description:
+        "Query the sandbox database for documnets that match the user or plugin requests",
+      execute: async (context: AgentContext): Promise<PluginResult> => {
+        // Construct query from context
+        const queryFormattedResponse = await this.runtime.operations.getObject(
+          SQLiteQuerySchema,
+          generateQueryTemplate(context.contextChain, ["id", "content"]),
+          { temperature: 0.2 }
+        );
+        const queryStmt = this.db.prepare(queryFormattedResponse.query);
+        const results = queryStmt.all() as { id: string; content: string }[];
+
+        return {
+          success: true,
+          data: { results }
         };
       }
     });

--- a/packages/memory-sqlite/src/plugin.ts
+++ b/packages/memory-sqlite/src/plugin.ts
@@ -1,12 +1,13 @@
-import Database, { Statement } from "better-sqlite3";
+import Database from "better-sqlite3";
 
 import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
+
 import { SQLiteDatabase } from "./database";
-import { SQLiteMemoryUploadSchema, SQLiteQuerySchema } from "./types";
 import {
-  generateUploadDocumnetTemplate,
-  generateQueryTemplate
+  generateQueryTemplate,
+  generateUploadDocumentTemplate
 } from "./templates";
+import { SQLiteMemoryUploadSchema, SQLiteQuerySchema } from "./types";
 
 export class SQLiteMemoryPlugin extends PluginBase {
   private db: Database.Database;
@@ -22,22 +23,22 @@ export class SQLiteMemoryPlugin extends PluginBase {
     this.db = SQLiteDatabase.getInstance().getDatabase();
     // Make new sandbox table
     this.db.exec(`
-                CREATE TABLE IF NOT EXISTS sandbox (
-                    id TEXT PRIMARY KEY,
-                    conversation_id TEXT NOT NULL,
-                    content TEXT NOT NULL,
-                    timestamp BIGINT NOT NULL,
-                    FOREIGN KEY (conversation_id) REFERENCES conversations(id)
-                )
-        `);
+      CREATE TABLE IF NOT EXISTS sandbox (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp BIGINT NOT NULL,
+        FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+      )
+    `);
 
     this.addExecutor({
       name: "memory:add_document",
       description: "Add a peice of information into the sandboxed database",
       execute: async (context: AgentContext): Promise<PluginResult> => {
         const stmt = this.db.prepare(`
-            INSERT INTO sandbox (id, conversation_id, content, timestamp)
-            VALUES (?, ?, ?, ?)
+          INSERT INTO sandbox (id, conversation_id, content, timestamp)
+          VALUES (?, ?, ?, ?)
         `);
 
         const timestamp = Date.now();
@@ -46,27 +47,22 @@ export class SQLiteMemoryPlugin extends PluginBase {
         // Get data to store in database from context chain
         const formattedResponse = await this.runtime.operations.getObject(
           SQLiteMemoryUploadSchema,
-          generateUploadDocumnetTemplate(context.contextChain),
+          generateUploadDocumentTemplate(context.contextChain),
           { temperature: 0.2 }
         );
 
-        // Query to get the most recent conversation ID from the conversations table
-        const getLatestConversationStmt = this.db.prepare(`
-            SELECT id FROM conversations 
-            ORDER BY created_at DESC 
-            LIMIT 1
-        `);
-
-        const latestConversation = getLatestConversationStmt.get() as {
-          id: string;
-        };
-        if (!latestConversation.id) {
-          throw new Error("No conversations found");
+        // Get conversation ID from context
+        const conversationId = context.conversationId;
+        if (!conversationId) {
+          return {
+            success: false,
+            data: { message: "Conversation ID not available in agent context" }
+          };
         }
 
         stmt.run(
           documentId,
-          latestConversation.id,
+          conversationId,
           formattedResponse.content,
           timestamp
         );
@@ -90,7 +86,6 @@ export class SQLiteMemoryPlugin extends PluginBase {
         );
         const queryStmt = this.db.prepare(queryFormattedResponse.query);
         const queryResults = queryStmt.all() as { id: string }[];
-
         if (queryResults.length === 0) {
           return {
             success: false,
@@ -100,21 +95,12 @@ export class SQLiteMemoryPlugin extends PluginBase {
           };
         }
 
-        let deleteStmt: Statement;
-        const documentIds = queryResults.map((result) => result.id).join(", ");
-        if (queryResults.length === 1) {
-          deleteStmt = this.db.prepare(`
-            DELETE FROM sandbox
-            WHERE id = '${queryResults[0]?.id}'
-          `);
-        } else {
-          deleteStmt = this.db.prepare(`
-              DELETE FROM sandbox 
-              WHERE id IN (${documentIds})
-          `);
-        }
-
-        const result = deleteStmt.run();
+        const documentIds = queryResults.map((result) => result.id);
+        const deleteStmt = this.db.prepare(`
+          DELETE FROM sandbox 
+          WHERE id IN (${queryResults.map(() => "?").join(",")})
+        `);
+        const result = deleteStmt.run(...documentIds);
         if (result.changes === 0) {
           return {
             success: false,
@@ -144,7 +130,6 @@ export class SQLiteMemoryPlugin extends PluginBase {
         );
         const queryStmt = this.db.prepare(queryFormattedResponse.query);
         const results = queryStmt.all() as { id: string; content: string }[];
-
         return {
           success: true,
           data: { results }

--- a/packages/memory-sqlite/src/plugin.ts
+++ b/packages/memory-sqlite/src/plugin.ts
@@ -1,0 +1,70 @@
+import Database from "better-sqlite3";
+
+import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
+import { SQLiteDatabase } from "./database";
+
+export class SQLiteMemoryPlugin extends PluginBase {
+  private db: Database.Database;
+
+  constructor() {
+    super({
+      id: "plugin-sqlite-memory",
+      name: "SQLite Memory Plugin",
+      description: "Memory plugin for SQLite"
+    });
+
+    // Get database connection instance
+    this.db = SQLiteDatabase.getInstance().getDatabase();
+    // Make new sandbox table
+    this.db.exec(`
+                CREATE TABLE IF NOT EXISTS sandbox (
+                    id TEXT PRIMARY KEY,
+                    conversation_id TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    timestamp INTEGER NOT NULL,
+                    plugin_id TEXT,
+                    FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+                )
+        `);
+
+    this.addExecutor({
+      name: "memory:add_document",
+      description: "Add a peice of information into the sandboxed database",
+      execute: async (context: AgentContext): Promise<PluginResult> => {
+        const stmt = this.db.prepare(`
+                    INSERT INTO sandbox (id, conversation_id, content, timestamp, plugin_id)
+                    VALUES (?, ?, ?, ?, ?)
+                `);
+
+        const timestamp = Date.now();
+        const documentId = `doc_${timestamp}_${Math.random().toString(36).substr(2, 9)}`;
+
+        // Add most recent peice of context to the sandbox database
+        const contextItem =
+          context.contextChain[context.contextChain.length - 1];
+
+        // Query to get the most recent conversation ID from the conversations table
+        const getLatestConversationStmt = this.db.prepare(`
+                    SELECT id FROM conversations 
+                    ORDER BY timestamp DESC 
+                    LIMIT 1
+                `);
+
+        const latestConversation = getLatestConversationStmt.get();
+
+        stmt.run(
+          documentId,
+          latestConversation,
+          contextItem?.content,
+          timestamp,
+          this.id
+        );
+
+        return {
+          success: true,
+          data: { documentId }
+        };
+      }
+    });
+  }
+}

--- a/packages/memory-sqlite/src/provider.ts
+++ b/packages/memory-sqlite/src/provider.ts
@@ -8,11 +8,13 @@ import {
   Conversation,
   MemoryProvider,
   MemoryQueryOptions,
-  Message
+  Message,
+  Plugin
 } from "@maiar-ai/core";
-import { SQLiteConfig } from "./types";
+
 import { SQLiteDatabase } from "./database";
 import { SQLiteMemoryPlugin } from "./plugin";
+import { SQLiteConfig } from "./types";
 
 type JSONValue =
   | string

--- a/packages/memory-sqlite/src/templates.ts
+++ b/packages/memory-sqlite/src/templates.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-useless-escape */
 import { BaseContextItem } from "@maiar-ai/core";
 
-export function generateUploadDocumnetTemplate(
+export function generateUploadDocumentTemplate(
   contextChain: BaseContextItem[]
 ): string {
   return `Generate a response based on the context chain. Your response should be a JSON object with a single "content" field containing your response.

--- a/packages/memory-sqlite/src/templates.ts
+++ b/packages/memory-sqlite/src/templates.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-useless-escape */
+import { BaseContextItem } from "@maiar-ai/core";
+
+export function generateUploadDocumnetTemplate(
+  contextChain: BaseContextItem[]
+): string {
+  return `Generate a response based on the context chain. Your response should be a JSON object with a single "content" field containing your response.
+        The response should be the exact text that should be uploaded to the sandbox database for later use.
+
+        IMPORTANT: Your response MUST be valid JSON:
+        - Use double quotes (") not single quotes (')
+        - Escape any quotes within strings with backslash (\")
+        - Do not use smart/curly quotes
+        - The response must be parseable by JSON.parse()
+
+        Do NOT include any metadata, context information, or explanation of how the response was generated.
+        Look for the relevant information in the most recent context items (e.g. generated text, current time, etc).
+
+        Here is the Context Chain, it contains all messages from the user and plugin response. Your job is to find the content
+        that the user or plugin wants to upload to the database for future use and generate a response with just that information.
+        Make sure to keep the content exactly how it was presented by the user or plugin.
+        ${JSON.stringify(contextChain, null, 2)}
+
+        Example of a valid response:
+        {
+            "content": "This is example text to upload to the database"
+        }
+    `;
+}
+
+export function generateQueryTemplate(
+  contextChain: BaseContextItem[],
+  properties: string[] | string = "id"
+): string {
+  return `Generate a response based on the context chain. Your response should be a JSON object with a single "query" field containing a valid SQL query.
+        The query should be a search on the sandbox table that returns document values ${properties}.
+
+        IMPORTANT: Your response MUST be valid JSON:
+        - Use double quotes (") not single quotes (')
+        - Escape any quotes within strings with backslash (\")
+        - Do not use smart/curly quotes
+        - The response must be parseable by JSON.parse()
+
+        Do NOT include any metadata, context information, or explanation of how the response was generated.
+        Look for the relevant information in the most recent context items (e.g. generated text, current time, etc).
+
+        Here is the context chain, it contains all messages from the user and plugin responses. Your job is to construct
+        a query on the sandbox table that satisifes the users or plugins request outlined in the context chain.
+        Make sure to only respond with the documnet ids that match the query.
+        ${JSON.stringify(contextChain, null, 2)}
+
+        Example of a valid response:
+        {
+            "query": "SELECT id FROM sandbox WHERE content == 'This is the content of a test document'"
+        }
+    `;
+}

--- a/packages/memory-sqlite/src/types.ts
+++ b/packages/memory-sqlite/src/types.ts
@@ -1,3 +1,13 @@
+import { z } from "zod";
+
 export interface SQLiteConfig {
   dbPath: string;
 }
+
+export const SQLiteMemoryUploadSchema = z.object({
+  content: z.string().describe("The response data to send back to the client")
+});
+
+export const SQLiteQuerySchema = z.object({
+  query: z.string().describe("SQL query string")
+});

--- a/packages/memory-sqlite/src/types.ts
+++ b/packages/memory-sqlite/src/types.ts
@@ -1,0 +1,3 @@
+export interface SQLiteConfig {
+  dbPath: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11992,13 +11992,6 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
-  postcss@8.5.1:
-    resolution:
-      {
-        integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==
-      }
-    engines: { node: ^10 || ^12 || >=14 }
-
   postcss@8.5.3:
     resolution:
       {
@@ -15961,215 +15954,215 @@ snapshots:
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
 
-  "@csstools/postcss-cascade-layers@5.0.1(postcss@8.5.1)":
+  "@csstools/postcss-cascade-layers@5.0.1(postcss@8.5.3)":
     dependencies:
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  "@csstools/postcss-color-function@4.0.7(postcss@8.5.1)":
+  "@csstools/postcss-color-function@4.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-color-mix-function@3.0.7(postcss@8.5.1)":
+  "@csstools/postcss-color-mix-function@3.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-content-alt-text@2.0.4(postcss@8.5.1)":
+  "@csstools/postcss-content-alt-text@2.0.4(postcss@8.5.3)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-exponential-functions@2.0.6(postcss@8.5.1)":
+  "@csstools/postcss-exponential-functions@2.0.6(postcss@8.5.3)":
     dependencies:
       "@csstools/css-calc": 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.1)":
+  "@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.3)":
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-gamut-mapping@2.0.7(postcss@8.5.1)":
+  "@csstools/postcss-gamut-mapping@2.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-gradients-interpolation-method@5.0.7(postcss@8.5.1)":
+  "@csstools/postcss-gradients-interpolation-method@5.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-hwb-function@4.0.7(postcss@8.5.1)":
+  "@csstools/postcss-hwb-function@4.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-ic-unit@4.0.0(postcss@8.5.1)":
+  "@csstools/postcss-ic-unit@4.0.0(postcss@8.5.3)":
     dependencies:
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-initial@2.0.0(postcss@8.5.1)":
+  "@csstools/postcss-initial@2.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.5.1)":
+  "@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.5.3)":
     dependencies:
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  "@csstools/postcss-light-dark-function@2.0.7(postcss@8.5.1)":
+  "@csstools/postcss-light-dark-function@2.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.1)":
+  "@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.1)":
+  "@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.1)":
+  "@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-logical-resize@3.0.0(postcss@8.5.1)":
+  "@csstools/postcss-logical-resize@3.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.5.1)":
+  "@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.5.3)":
     dependencies:
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-media-minmax@2.0.6(postcss@8.5.1)":
+  "@csstools/postcss-media-minmax@2.0.6(postcss@8.5.3)":
     dependencies:
       "@csstools/css-calc": 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
       "@csstools/media-query-list-parser": 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.5.1)":
+  "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.5.3)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
       "@csstools/media-query-list-parser": 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-nested-calc@4.0.0(postcss@8.5.1)":
+  "@csstools/postcss-nested-calc@4.0.0(postcss@8.5.3)":
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-normalize-display-values@4.0.0(postcss@8.5.1)":
+  "@csstools/postcss-normalize-display-values@4.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-oklab-function@4.0.7(postcss@8.5.1)":
+  "@csstools/postcss-oklab-function@4.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-progressive-custom-properties@4.0.0(postcss@8.5.1)":
+  "@csstools/postcss-progressive-custom-properties@4.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-random-function@1.0.2(postcss@8.5.1)":
+  "@csstools/postcss-random-function@1.0.2(postcss@8.5.3)":
     dependencies:
       "@csstools/css-calc": 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-relative-color-syntax@3.0.7(postcss@8.5.1)":
+  "@csstools/postcss-relative-color-syntax@3.0.7(postcss@8.5.3)":
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  "@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.1)":
+  "@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  "@csstools/postcss-sign-functions@1.1.1(postcss@8.5.1)":
+  "@csstools/postcss-sign-functions@1.1.1(postcss@8.5.3)":
     dependencies:
       "@csstools/css-calc": 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-stepped-value-functions@4.0.6(postcss@8.5.1)":
+  "@csstools/postcss-stepped-value-functions@4.0.6(postcss@8.5.3)":
     dependencies:
       "@csstools/css-calc": 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-text-decoration-shorthand@4.0.1(postcss@8.5.1)":
+  "@csstools/postcss-text-decoration-shorthand@4.0.1(postcss@8.5.3)":
     dependencies:
       "@csstools/color-helpers": 5.0.1
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-trigonometric-functions@4.0.6(postcss@8.5.1)":
+  "@csstools/postcss-trigonometric-functions@4.0.6(postcss@8.5.3)":
     dependencies:
       "@csstools/css-calc": 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  "@csstools/postcss-unset-value@4.0.0(postcss@8.5.1)":
+  "@csstools/postcss-unset-value@4.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
   "@csstools/selector-resolve-nested@3.0.0(postcss-selector-parser@7.0.0)":
     dependencies:
@@ -16179,9 +16172,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.0.0
 
-  "@csstools/utilities@2.0.0(postcss@8.5.1)":
+  "@csstools/utilities@2.0.0(postcss@8.5.3)":
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
   "@discordjs/builders@1.10.1":
     dependencies:
@@ -16288,14 +16281,14 @@ snapshots:
       copy-webpack-plugin: 11.0.0(webpack@5.97.1(esbuild@0.24.2))
       css-loader: 6.11.0(webpack@5.97.1(esbuild@0.24.2))
       css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
-      cssnano: 6.1.2(postcss@8.5.1)
+      cssnano: 6.1.2(postcss@8.5.3)
       file-loader: 6.2.0(webpack@5.97.1(esbuild@0.24.2))
       html-minifier-terser: 7.2.0
       mini-css-extract-plugin: 2.9.2(webpack@5.97.1(esbuild@0.24.2))
       null-loader: 4.0.1(webpack@5.97.1(esbuild@0.24.2))
-      postcss: 8.5.1
-      postcss-loader: 7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
-      postcss-preset-env: 10.1.3(postcss@8.5.1)
+      postcss: 8.5.3
+      postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
+      postcss-preset-env: 10.1.3(postcss@8.5.3)
       react-dev-utils: 12.0.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2))
       terser-webpack-plugin: 5.3.11(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2))
       tslib: 2.8.1
@@ -16389,9 +16382,9 @@ snapshots:
 
   "@docusaurus/cssnano-preset@3.7.0":
     dependencies:
-      cssnano-preset-advanced: 6.1.2(postcss@8.5.1)
-      postcss: 8.5.1
-      postcss-sort-media-queries: 5.2.0(postcss@8.5.1)
+      cssnano-preset-advanced: 6.1.2(postcss@8.5.3)
+      postcss: 8.5.3
+      postcss-sort-media-queries: 5.2.0(postcss@8.5.3)
       tslib: 2.8.1
 
   "@docusaurus/logger@3.7.0":
@@ -16827,7 +16820,7 @@ snapshots:
       infima: 0.2.0-alpha.45
       lodash: 4.17.21
       nprogress: 0.2.0
-      postcss: 8.5.1
+      postcss: 8.5.3
       prism-react-renderer: 2.4.1(react@19.0.0)
       prismjs: 1.29.0
       react: 19.0.0
@@ -18881,14 +18874,14 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.4.20(postcss@8.5.1):
+  autoprefixer@10.4.20(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-lite: 1.0.30001696
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
   axios@1.7.9:
@@ -19564,30 +19557,30 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-blank-pseudo@7.0.1(postcss@8.5.1):
+  css-blank-pseudo@7.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  css-declaration-sorter@7.2.0(postcss@8.5.1):
+  css-declaration-sorter@7.2.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  css-has-pseudo@7.0.2(postcss@8.5.1):
+  css-has-pseudo@7.0.2(postcss@8.5.3):
     dependencies:
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
       postcss-value-parser: 4.2.0
 
   css-loader@6.11.0(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.1)
-      postcss: 8.5.1
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.1)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.1)
-      postcss-modules-scope: 3.2.1(postcss@8.5.1)
-      postcss-modules-values: 4.0.0(postcss@8.5.1)
+      icss-utils: 5.1.0(postcss@8.5.3)
+      postcss: 8.5.3
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.3)
+      postcss-modules-scope: 3.2.1(postcss@8.5.3)
+      postcss-modules-values: 4.0.0(postcss@8.5.3)
       postcss-value-parser: 4.2.0
       semver: 7.7.0
     optionalDependencies:
@@ -19596,9 +19589,9 @@ snapshots:
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.25
-      cssnano: 6.1.2(postcss@8.5.1)
+      cssnano: 6.1.2(postcss@8.5.3)
       jest-worker: 29.7.0
-      postcss: 8.5.1
+      postcss: 8.5.3
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       webpack: 5.97.1(esbuild@0.24.2)
@@ -19606,9 +19599,9 @@ snapshots:
       clean-css: 5.3.3
       esbuild: 0.24.2
 
-  css-prefers-color-scheme@10.0.0(postcss@8.5.1):
+  css-prefers-color-scheme@10.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
   css-select@4.3.0:
     dependencies:
@@ -19642,60 +19635,60 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-advanced@6.1.2(postcss@8.5.1):
+  cssnano-preset-advanced@6.1.2(postcss@8.5.3):
     dependencies:
-      autoprefixer: 10.4.20(postcss@8.5.1)
+      autoprefixer: 10.4.20(postcss@8.5.3)
       browserslist: 4.24.4
-      cssnano-preset-default: 6.1.2(postcss@8.5.1)
-      postcss: 8.5.1
-      postcss-discard-unused: 6.0.5(postcss@8.5.1)
-      postcss-merge-idents: 6.0.3(postcss@8.5.1)
-      postcss-reduce-idents: 6.0.3(postcss@8.5.1)
-      postcss-zindex: 6.0.2(postcss@8.5.1)
+      cssnano-preset-default: 6.1.2(postcss@8.5.3)
+      postcss: 8.5.3
+      postcss-discard-unused: 6.0.5(postcss@8.5.3)
+      postcss-merge-idents: 6.0.3(postcss@8.5.3)
+      postcss-reduce-idents: 6.0.3(postcss@8.5.3)
+      postcss-zindex: 6.0.2(postcss@8.5.3)
 
-  cssnano-preset-default@6.1.2(postcss@8.5.1):
+  cssnano-preset-default@6.1.2(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
-      css-declaration-sorter: 7.2.0(postcss@8.5.1)
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
-      postcss-calc: 9.0.1(postcss@8.5.1)
-      postcss-colormin: 6.1.0(postcss@8.5.1)
-      postcss-convert-values: 6.1.0(postcss@8.5.1)
-      postcss-discard-comments: 6.0.2(postcss@8.5.1)
-      postcss-discard-duplicates: 6.0.3(postcss@8.5.1)
-      postcss-discard-empty: 6.0.3(postcss@8.5.1)
-      postcss-discard-overridden: 6.0.2(postcss@8.5.1)
-      postcss-merge-longhand: 6.0.5(postcss@8.5.1)
-      postcss-merge-rules: 6.1.1(postcss@8.5.1)
-      postcss-minify-font-values: 6.1.0(postcss@8.5.1)
-      postcss-minify-gradients: 6.0.3(postcss@8.5.1)
-      postcss-minify-params: 6.1.0(postcss@8.5.1)
-      postcss-minify-selectors: 6.0.4(postcss@8.5.1)
-      postcss-normalize-charset: 6.0.2(postcss@8.5.1)
-      postcss-normalize-display-values: 6.0.2(postcss@8.5.1)
-      postcss-normalize-positions: 6.0.2(postcss@8.5.1)
-      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.1)
-      postcss-normalize-string: 6.0.2(postcss@8.5.1)
-      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.1)
-      postcss-normalize-unicode: 6.1.0(postcss@8.5.1)
-      postcss-normalize-url: 6.0.2(postcss@8.5.1)
-      postcss-normalize-whitespace: 6.0.2(postcss@8.5.1)
-      postcss-ordered-values: 6.0.2(postcss@8.5.1)
-      postcss-reduce-initial: 6.1.0(postcss@8.5.1)
-      postcss-reduce-transforms: 6.0.2(postcss@8.5.1)
-      postcss-svgo: 6.0.3(postcss@8.5.1)
-      postcss-unique-selectors: 6.0.4(postcss@8.5.1)
+      css-declaration-sorter: 7.2.0(postcss@8.5.3)
+      cssnano-utils: 4.0.2(postcss@8.5.3)
+      postcss: 8.5.3
+      postcss-calc: 9.0.1(postcss@8.5.3)
+      postcss-colormin: 6.1.0(postcss@8.5.3)
+      postcss-convert-values: 6.1.0(postcss@8.5.3)
+      postcss-discard-comments: 6.0.2(postcss@8.5.3)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.3)
+      postcss-discard-empty: 6.0.3(postcss@8.5.3)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.3)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.3)
+      postcss-merge-rules: 6.1.1(postcss@8.5.3)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.3)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.3)
+      postcss-minify-params: 6.1.0(postcss@8.5.3)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.3)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.3)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.3)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.3)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.3)
+      postcss-normalize-string: 6.0.2(postcss@8.5.3)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.3)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.3)
+      postcss-normalize-url: 6.0.2(postcss@8.5.3)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.3)
+      postcss-ordered-values: 6.0.2(postcss@8.5.3)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.3)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.3)
+      postcss-svgo: 6.0.3(postcss@8.5.3)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.3)
 
-  cssnano-utils@4.0.2(postcss@8.5.1):
+  cssnano-utils@4.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  cssnano@6.1.2(postcss@8.5.1):
+  cssnano@6.1.2(postcss@8.5.3):
     dependencies:
-      cssnano-preset-default: 6.1.2(postcss@8.5.1)
+      cssnano-preset-default: 6.1.2(postcss@8.5.3)
       lilconfig: 3.1.3
-      postcss: 8.5.1
+      postcss: 8.5.3
 
   csso@5.0.5:
     dependencies:
@@ -21053,9 +21046,9 @@ snapshots:
       safer-buffer: 2.1.2
     optional: true
 
-  icss-utils@5.1.0(postcss@8.5.1):
+  icss-utils@5.1.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
   ieee754@1.2.1: {}
 
@@ -22975,147 +22968,147 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.1):
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-calc@9.0.1(postcss@8.5.1):
+  postcss-calc@9.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  postcss-clamp@4.1.0(postcss@8.5.1):
+  postcss-clamp@4.1.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@7.0.7(postcss@8.5.1):
+  postcss-color-functional-notation@7.0.7(postcss@8.5.3):
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  postcss-color-hex-alpha@10.0.0(postcss@8.5.1):
+  postcss-color-hex-alpha@10.0.0(postcss@8.5.3):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@10.0.0(postcss@8.5.1):
+  postcss-color-rebeccapurple@10.0.0(postcss@8.5.3):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@6.1.0(postcss@8.5.1):
+  postcss-colormin@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@6.1.0(postcss@8.5.1):
+  postcss-convert-values@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-custom-media@11.0.5(postcss@8.5.1):
+  postcss-custom-media@11.0.5(postcss@8.5.3):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
       "@csstools/media-query-list-parser": 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-custom-properties@14.0.4(postcss@8.5.1):
+  postcss-custom-properties@14.0.4(postcss@8.5.3):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@8.0.4(postcss@8.5.1):
+  postcss-custom-selectors@8.0.4(postcss@8.5.3):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-dir-pseudo-class@9.0.1(postcss@8.5.1):
+  postcss-dir-pseudo-class@9.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-discard-comments@6.0.2(postcss@8.5.1):
+  postcss-discard-comments@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-discard-duplicates@6.0.3(postcss@8.5.1):
+  postcss-discard-duplicates@6.0.3(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-discard-empty@6.0.3(postcss@8.5.1):
+  postcss-discard-empty@6.0.3(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-discard-overridden@6.0.2(postcss@8.5.1):
+  postcss-discard-overridden@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-discard-unused@6.0.5(postcss@8.5.1):
+  postcss-discard-unused@6.0.5(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
-  postcss-double-position-gradients@6.0.0(postcss@8.5.1):
+  postcss-double-position-gradients@6.0.0(postcss@8.5.3):
     dependencies:
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-focus-visible@10.0.1(postcss@8.5.1):
+  postcss-focus-visible@10.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-focus-within@9.0.1(postcss@8.5.1):
+  postcss-focus-within@9.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-font-variant@5.0.0(postcss@8.5.1):
+  postcss-font-variant@5.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-gap-properties@6.0.0(postcss@8.5.1):
+  postcss-gap-properties@6.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-image-set-function@7.0.0(postcss@8.5.1):
+  postcss-image-set-function@7.0.0(postcss@8.5.3):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-lab-function@7.0.7(postcss@8.5.1):
+  postcss-lab-function@7.0.7(postcss@8.5.3):
     dependencies:
       "@csstools/css-color-parser": 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-parser-algorithms": 3.0.4(@csstools/css-tokenizer@3.0.3)
       "@csstools/css-tokenizer": 3.0.3
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/utilities": 2.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/utilities": 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
   postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
@@ -23126,257 +23119,257 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  postcss-loader@7.3.4(postcss@8.5.1)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
+  postcss-loader@7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.97.1(esbuild@0.24.2)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.7.3)
       jiti: 1.21.7
-      postcss: 8.5.1
+      postcss: 8.5.3
       semver: 7.7.0
       webpack: 5.97.1(esbuild@0.24.2)
     transitivePeerDependencies:
       - typescript
 
-  postcss-logical@8.0.0(postcss@8.5.1):
+  postcss-logical@8.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-merge-idents@6.0.3(postcss@8.5.1):
+  postcss-merge-idents@6.0.3(postcss@8.5.3):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
+      cssnano-utils: 4.0.2(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-merge-longhand@6.0.5(postcss@8.5.1):
+  postcss-merge-longhand@6.0.5(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
-      stylehacks: 6.1.1(postcss@8.5.1)
+      stylehacks: 6.1.1(postcss@8.5.3)
 
-  postcss-merge-rules@6.1.1(postcss@8.5.1):
+  postcss-merge-rules@6.1.1(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-api: 3.0.0
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
+      cssnano-utils: 4.0.2(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
-  postcss-minify-font-values@6.1.0(postcss@8.5.1):
+  postcss-minify-font-values@6.1.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@6.0.3(postcss@8.5.1):
+  postcss-minify-gradients@6.0.3(postcss@8.5.3):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
+      cssnano-utils: 4.0.2(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@6.1.0(postcss@8.5.1):
+  postcss-minify-params@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
+      cssnano-utils: 4.0.2(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@6.0.4(postcss@8.5.1):
+  postcss-minify-selectors@6.0.4(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.1):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.1):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.3):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.1)
-      postcss: 8.5.1
+      icss-utils: 5.1.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.1):
+  postcss-modules-scope@3.2.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-modules-values@4.0.0(postcss@8.5.1):
+  postcss-modules-values@4.0.0(postcss@8.5.3):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.1)
-      postcss: 8.5.1
+      icss-utils: 5.1.0(postcss@8.5.3)
+      postcss: 8.5.3
 
-  postcss-nesting@13.0.1(postcss@8.5.1):
+  postcss-nesting@13.0.1(postcss@8.5.3):
     dependencies:
       "@csstools/selector-resolve-nested": 3.0.0(postcss-selector-parser@7.0.0)
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-normalize-charset@6.0.2(postcss@8.5.1):
+  postcss-normalize-charset@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-normalize-display-values@6.0.2(postcss@8.5.1):
+  postcss-normalize-display-values@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@6.0.2(postcss@8.5.1):
+  postcss-normalize-positions@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@6.0.2(postcss@8.5.1):
+  postcss-normalize-repeat-style@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@6.0.2(postcss@8.5.1):
+  postcss-normalize-string@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@6.0.2(postcss@8.5.1):
+  postcss-normalize-timing-functions@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@6.1.0(postcss@8.5.1):
+  postcss-normalize-unicode@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@6.0.2(postcss@8.5.1):
+  postcss-normalize-url@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@6.0.2(postcss@8.5.1):
+  postcss-normalize-whitespace@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-opacity-percentage@3.0.0(postcss@8.5.1):
+  postcss-opacity-percentage@3.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-ordered-values@6.0.2(postcss@8.5.1):
+  postcss-ordered-values@6.0.2(postcss@8.5.3):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
+      cssnano-utils: 4.0.2(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@6.0.0(postcss@8.5.1):
+  postcss-overflow-shorthand@6.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.5.1):
+  postcss-page-break@3.0.4(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-place@10.0.0(postcss@8.5.1):
+  postcss-place@10.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-preset-env@10.1.3(postcss@8.5.1):
+  postcss-preset-env@10.1.3(postcss@8.5.3):
     dependencies:
-      "@csstools/postcss-cascade-layers": 5.0.1(postcss@8.5.1)
-      "@csstools/postcss-color-function": 4.0.7(postcss@8.5.1)
-      "@csstools/postcss-color-mix-function": 3.0.7(postcss@8.5.1)
-      "@csstools/postcss-content-alt-text": 2.0.4(postcss@8.5.1)
-      "@csstools/postcss-exponential-functions": 2.0.6(postcss@8.5.1)
-      "@csstools/postcss-font-format-keywords": 4.0.0(postcss@8.5.1)
-      "@csstools/postcss-gamut-mapping": 2.0.7(postcss@8.5.1)
-      "@csstools/postcss-gradients-interpolation-method": 5.0.7(postcss@8.5.1)
-      "@csstools/postcss-hwb-function": 4.0.7(postcss@8.5.1)
-      "@csstools/postcss-ic-unit": 4.0.0(postcss@8.5.1)
-      "@csstools/postcss-initial": 2.0.0(postcss@8.5.1)
-      "@csstools/postcss-is-pseudo-class": 5.0.1(postcss@8.5.1)
-      "@csstools/postcss-light-dark-function": 2.0.7(postcss@8.5.1)
-      "@csstools/postcss-logical-float-and-clear": 3.0.0(postcss@8.5.1)
-      "@csstools/postcss-logical-overflow": 2.0.0(postcss@8.5.1)
-      "@csstools/postcss-logical-overscroll-behavior": 2.0.0(postcss@8.5.1)
-      "@csstools/postcss-logical-resize": 3.0.0(postcss@8.5.1)
-      "@csstools/postcss-logical-viewport-units": 3.0.3(postcss@8.5.1)
-      "@csstools/postcss-media-minmax": 2.0.6(postcss@8.5.1)
-      "@csstools/postcss-media-queries-aspect-ratio-number-values": 3.0.4(postcss@8.5.1)
-      "@csstools/postcss-nested-calc": 4.0.0(postcss@8.5.1)
-      "@csstools/postcss-normalize-display-values": 4.0.0(postcss@8.5.1)
-      "@csstools/postcss-oklab-function": 4.0.7(postcss@8.5.1)
-      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.1)
-      "@csstools/postcss-random-function": 1.0.2(postcss@8.5.1)
-      "@csstools/postcss-relative-color-syntax": 3.0.7(postcss@8.5.1)
-      "@csstools/postcss-scope-pseudo-class": 4.0.1(postcss@8.5.1)
-      "@csstools/postcss-sign-functions": 1.1.1(postcss@8.5.1)
-      "@csstools/postcss-stepped-value-functions": 4.0.6(postcss@8.5.1)
-      "@csstools/postcss-text-decoration-shorthand": 4.0.1(postcss@8.5.1)
-      "@csstools/postcss-trigonometric-functions": 4.0.6(postcss@8.5.1)
-      "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.1)
-      autoprefixer: 10.4.20(postcss@8.5.1)
+      "@csstools/postcss-cascade-layers": 5.0.1(postcss@8.5.3)
+      "@csstools/postcss-color-function": 4.0.7(postcss@8.5.3)
+      "@csstools/postcss-color-mix-function": 3.0.7(postcss@8.5.3)
+      "@csstools/postcss-content-alt-text": 2.0.4(postcss@8.5.3)
+      "@csstools/postcss-exponential-functions": 2.0.6(postcss@8.5.3)
+      "@csstools/postcss-font-format-keywords": 4.0.0(postcss@8.5.3)
+      "@csstools/postcss-gamut-mapping": 2.0.7(postcss@8.5.3)
+      "@csstools/postcss-gradients-interpolation-method": 5.0.7(postcss@8.5.3)
+      "@csstools/postcss-hwb-function": 4.0.7(postcss@8.5.3)
+      "@csstools/postcss-ic-unit": 4.0.0(postcss@8.5.3)
+      "@csstools/postcss-initial": 2.0.0(postcss@8.5.3)
+      "@csstools/postcss-is-pseudo-class": 5.0.1(postcss@8.5.3)
+      "@csstools/postcss-light-dark-function": 2.0.7(postcss@8.5.3)
+      "@csstools/postcss-logical-float-and-clear": 3.0.0(postcss@8.5.3)
+      "@csstools/postcss-logical-overflow": 2.0.0(postcss@8.5.3)
+      "@csstools/postcss-logical-overscroll-behavior": 2.0.0(postcss@8.5.3)
+      "@csstools/postcss-logical-resize": 3.0.0(postcss@8.5.3)
+      "@csstools/postcss-logical-viewport-units": 3.0.3(postcss@8.5.3)
+      "@csstools/postcss-media-minmax": 2.0.6(postcss@8.5.3)
+      "@csstools/postcss-media-queries-aspect-ratio-number-values": 3.0.4(postcss@8.5.3)
+      "@csstools/postcss-nested-calc": 4.0.0(postcss@8.5.3)
+      "@csstools/postcss-normalize-display-values": 4.0.0(postcss@8.5.3)
+      "@csstools/postcss-oklab-function": 4.0.7(postcss@8.5.3)
+      "@csstools/postcss-progressive-custom-properties": 4.0.0(postcss@8.5.3)
+      "@csstools/postcss-random-function": 1.0.2(postcss@8.5.3)
+      "@csstools/postcss-relative-color-syntax": 3.0.7(postcss@8.5.3)
+      "@csstools/postcss-scope-pseudo-class": 4.0.1(postcss@8.5.3)
+      "@csstools/postcss-sign-functions": 1.1.1(postcss@8.5.3)
+      "@csstools/postcss-stepped-value-functions": 4.0.6(postcss@8.5.3)
+      "@csstools/postcss-text-decoration-shorthand": 4.0.1(postcss@8.5.3)
+      "@csstools/postcss-trigonometric-functions": 4.0.6(postcss@8.5.3)
+      "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.3)
+      autoprefixer: 10.4.20(postcss@8.5.3)
       browserslist: 4.24.4
-      css-blank-pseudo: 7.0.1(postcss@8.5.1)
-      css-has-pseudo: 7.0.2(postcss@8.5.1)
-      css-prefers-color-scheme: 10.0.0(postcss@8.5.1)
+      css-blank-pseudo: 7.0.1(postcss@8.5.3)
+      css-has-pseudo: 7.0.2(postcss@8.5.3)
+      css-prefers-color-scheme: 10.0.0(postcss@8.5.3)
       cssdb: 8.2.3
-      postcss: 8.5.1
-      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.1)
-      postcss-clamp: 4.1.0(postcss@8.5.1)
-      postcss-color-functional-notation: 7.0.7(postcss@8.5.1)
-      postcss-color-hex-alpha: 10.0.0(postcss@8.5.1)
-      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.1)
-      postcss-custom-media: 11.0.5(postcss@8.5.1)
-      postcss-custom-properties: 14.0.4(postcss@8.5.1)
-      postcss-custom-selectors: 8.0.4(postcss@8.5.1)
-      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.1)
-      postcss-double-position-gradients: 6.0.0(postcss@8.5.1)
-      postcss-focus-visible: 10.0.1(postcss@8.5.1)
-      postcss-focus-within: 9.0.1(postcss@8.5.1)
-      postcss-font-variant: 5.0.0(postcss@8.5.1)
-      postcss-gap-properties: 6.0.0(postcss@8.5.1)
-      postcss-image-set-function: 7.0.0(postcss@8.5.1)
-      postcss-lab-function: 7.0.7(postcss@8.5.1)
-      postcss-logical: 8.0.0(postcss@8.5.1)
-      postcss-nesting: 13.0.1(postcss@8.5.1)
-      postcss-opacity-percentage: 3.0.0(postcss@8.5.1)
-      postcss-overflow-shorthand: 6.0.0(postcss@8.5.1)
-      postcss-page-break: 3.0.4(postcss@8.5.1)
-      postcss-place: 10.0.0(postcss@8.5.1)
-      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.1)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.1)
-      postcss-selector-not: 8.0.1(postcss@8.5.1)
+      postcss: 8.5.3
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.3)
+      postcss-clamp: 4.1.0(postcss@8.5.3)
+      postcss-color-functional-notation: 7.0.7(postcss@8.5.3)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.5.3)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.3)
+      postcss-custom-media: 11.0.5(postcss@8.5.3)
+      postcss-custom-properties: 14.0.4(postcss@8.5.3)
+      postcss-custom-selectors: 8.0.4(postcss@8.5.3)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.3)
+      postcss-double-position-gradients: 6.0.0(postcss@8.5.3)
+      postcss-focus-visible: 10.0.1(postcss@8.5.3)
+      postcss-focus-within: 9.0.1(postcss@8.5.3)
+      postcss-font-variant: 5.0.0(postcss@8.5.3)
+      postcss-gap-properties: 6.0.0(postcss@8.5.3)
+      postcss-image-set-function: 7.0.0(postcss@8.5.3)
+      postcss-lab-function: 7.0.7(postcss@8.5.3)
+      postcss-logical: 8.0.0(postcss@8.5.3)
+      postcss-nesting: 13.0.1(postcss@8.5.3)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.3)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.5.3)
+      postcss-page-break: 3.0.4(postcss@8.5.3)
+      postcss-place: 10.0.0(postcss@8.5.3)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.3)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.3)
+      postcss-selector-not: 8.0.1(postcss@8.5.3)
 
-  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.1):
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
-  postcss-reduce-idents@6.0.3(postcss@8.5.1):
+  postcss-reduce-idents@6.0.3(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@6.1.0(postcss@8.5.1):
+  postcss-reduce-initial@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-api: 3.0.0
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-reduce-transforms@6.0.2(postcss@8.5.1):
+  postcss-reduce-transforms@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.1):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-selector-not@8.0.1(postcss@8.5.1):
+  postcss-selector-not@8.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 7.0.0
 
   postcss-selector-parser@6.1.2:
@@ -23389,33 +23382,27 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sort-media-queries@5.2.0(postcss@8.5.1):
+  postcss-sort-media-queries@5.2.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       sort-css-media-queries: 2.2.0
 
-  postcss-svgo@6.0.3(postcss@8.5.1):
+  postcss-svgo@6.0.3(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
-  postcss-unique-selectors@6.0.4(postcss@8.5.1):
+  postcss-unique-selectors@6.0.4(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
   postcss-value-parser@4.2.0: {}
 
-  postcss-zindex@6.0.2(postcss@8.5.1):
+  postcss-zindex@6.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
-
-  postcss@8.5.1:
-    dependencies:
-      nanoid: 3.3.8
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
+      postcss: 8.5.3
 
   postcss@8.5.3:
     dependencies:
@@ -24041,7 +24028,7 @@ snapshots:
     dependencies:
       escalade: 3.2.0
       picocolors: 1.1.1
-      postcss: 8.5.1
+      postcss: 8.5.3
       strip-json-comments: 3.1.1
 
   run-async@2.4.1: {}
@@ -24470,10 +24457,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  stylehacks@6.1.1(postcss@8.5.1):
+  stylehacks@6.1.1(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
   stylis@4.2.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       "@maiar-ai/core":
         specifier: workspace:*
         version: link:../packages/core
+      "@maiar-ai/memory-filesystem":
+        specifier: workspace:*
+        version: link:../packages/memory-filesystem
       "@maiar-ai/memory-postgres":
         specifier: workspace:*
         version: link:../packages/memory-postgres
@@ -247,6 +250,9 @@ importers:
       "@maiar-ai/core":
         specifier: workspace:*
         version: link:../core
+      zod:
+        specifier: 3.24.1
+        version: 3.24.1
     devDependencies:
       "@types/node":
         specifier: 22.13.1
@@ -269,6 +275,9 @@ importers:
       pg-pool:
         specifier: 3.6.1
         version: 3.6.1(pg@8.14.1)
+      zod:
+        specifier: 3.24.1
+        version: 3.24.1
     devDependencies:
       "@types/node":
         specifier: 22.13.1
@@ -291,6 +300,9 @@ importers:
       better-sqlite3:
         specifier: 11.8.1
         version: 11.8.1
+      zod:
+        specifier: 3.24.1
+        version: 3.24.1
     devDependencies:
       "@types/better-sqlite3":
         specifier: 7.6.12


### PR DESCRIPTION
The best RFC is code

## Description

- Created plugins for SQLite, Postgres and FileSystem based memory providers
  - Extends `PluginBase` and implements executors that get registered like normal plugins
  - Executors for all Memory plugins implement `memory:add_document`, `memory:remove_document` and `memory:query`
- For Postgres and SQLite database singleton classes were created to handle database connections

## Related Issues

Closes #43 

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

Postgres memory provider test

https://github.com/user-attachments/assets/d5d153c1-2bca-4524-8453-b29bc97d610e

SQLite memory provider test

https://github.com/user-attachments/assets/373e4d53-d05c-4e50-9299-043a0b7f4bfc

FileSystem memory provider test

https://github.com/user-attachments/assets/5874991a-bbe2-4e1c-902e-f129d8cd5729

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
