### PR TITLE
chore(setup): 🔧 add import sorting to prettier config

### DIFF
--- a/.github/scripts/bounty/calculate-bounty.js
+++ b/.github/scripts/bounty/calculate-bounty.js
@@ -1,4 +1,5 @@
 import { appendFileSync } from "fs";
+
 import { GithubService, MAIAR_SYMBOL } from "../lib/github.js";
 
 /**

--- a/.github/scripts/bounty/extract-issues.js
+++ b/.github/scripts/bounty/extract-issues.js
@@ -1,4 +1,5 @@
 import { appendFileSync } from "fs";
+
 import { GithubService } from "../lib/github.js";
 
 /**

--- a/.github/scripts/bounty/extract-wallet.js
+++ b/.github/scripts/bounty/extract-wallet.js
@@ -1,4 +1,5 @@
 import { appendFileSync } from "fs";
+
 import { GithubService } from "../lib/github.js";
 
 /**

--- a/.github/scripts/bounty/filter-bounty-issues.js
+++ b/.github/scripts/bounty/filter-bounty-issues.js
@@ -1,5 +1,6 @@
 import { appendFileSync } from "fs";
-import { GithubService, BOUNTY_PAID_LABEL } from "../lib/github.js";
+
+import { BOUNTY_PAID_LABEL, GithubService } from "../lib/github.js";
 
 /**
  * Main function that filters bounty issues that have not been paid

--- a/.github/scripts/bounty/label-issues-paid.js
+++ b/.github/scripts/bounty/label-issues-paid.js
@@ -1,4 +1,4 @@
-import { GithubService, BOUNTY_PAID_LABEL } from "../lib/github.js";
+import { BOUNTY_PAID_LABEL, GithubService } from "../lib/github.js";
 
 /**
  * Main function that labels bounty issues on Github with the `bounty paid` label

--- a/.github/scripts/lib/github.js
+++ b/.github/scripts/lib/github.js
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
 import { getOctokit } from "@actions/github";
+import { readFileSync } from "fs";
 
 // Constants
 export const MAIAR_SYMBOL = "$MAIAR";

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,22 @@
   "tabWidth": 2,
   "singleQuote": false,
   "trailingComma": "none",
-  "semi": true
+  "semi": true,
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "importOrder": [
+    "dotenv/config",
+    "^react",
+    "^vite",
+    "<THIRD_PARTY_MODULES>",
+    "^@maiar-ai/core",
+    "^@maiar-ai/model(.*)$",
+    "^@maiar-ai/memory(.*)$",
+    "^@maiar-ai/monitor(.*)$",
+    "^@maiar-ai/plugin(.*)$",
+    "^[./]",
+    "^[../]"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrderCaseInsensitive": true
 }

--- a/README.md
+++ b/README.md
@@ -59,15 +59,19 @@ pnpm add @maiar-ai/core @maiar-ai/model-openai @maiar-ai/memory-sqlite @maiar-ai
 
 ```typescript
 import "dotenv/config";
+
+import path from "path";
+
 import { createRuntime } from "@maiar-ai/core";
+
 import { OpenAIProvider } from "@maiar-ai/model-openai";
+
 import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
 
 import { ConsoleMonitorProvider } from "@maiar-ai/monitor-console";
 
-import { PluginTextGeneration } from "@maiar-ai/plugin-text";
 import { PluginTerminal } from "@maiar-ai/plugin-terminal";
-import path from "path";
+import { PluginTextGeneration } from "@maiar-ai/plugin-text";
 
 const runtime = createRuntime({
   models: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,7 @@
 // @ts-check
-
 import eslint from "@eslint/js";
-import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config([
   {

--- a/maiar-client/README.md
+++ b/maiar-client/README.md
@@ -60,6 +60,7 @@ To enable the WebSocket monitor in your Maiar agent, add the provider to your ag
 
 ```typescript
 import { createRuntime } from "@maiar-ai/core";
+
 import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
 
 const runtime = createRuntime({
@@ -83,6 +84,7 @@ If you need to configure a custom port or path for the WebSocket connection, you
 
 ```typescript
 import { createRuntime } from "@maiar-ai/core";
+
 import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
 
 const runtime = createRuntime({
@@ -134,9 +136,11 @@ The chat panel connects to a default endpoint of `http://localhost:3002/message`
 To enable chat functionality in your Maiar agent, you need to add the Express plugin to your agent configuration:
 
 ```typescript
-import { createRuntime } from "@maiar-ai/core";
-import { ExpressPlugin } from "@maiar-ai/plugin-express";
 import { Router } from "express";
+
+import { createRuntime } from "@maiar-ai/core";
+
+import { ExpressPlugin } from "@maiar-ai/plugin-express";
 
 // Create a router with the required /message endpoint
 const router = Router();

--- a/maiar-client/eslint.config.js
+++ b/maiar-client/eslint.config.js
@@ -1,7 +1,7 @@
 import js from "@eslint/js";
-import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(

--- a/maiar-client/src/App.tsx
+++ b/maiar-client/src/App.tsx
@@ -1,14 +1,16 @@
-import { useMonitorSocket } from "./hooks/useMonitorSocket";
-import { CurrentPipeline } from "./components/CurrentPipeline";
-import { CurrentContextChain } from "./components/CurrentContextChain";
-import { Events } from "./components/Events";
-import { Chat } from "./components/Chat";
+import { useEffect, useState } from "react";
+
+import { AppBar, Box, Toolbar, Typography } from "@mui/material";
+
 import { AgentStatus } from "./components/AgentStatus";
+import { Chat } from "./components/Chat";
 import { ConnectionSettings } from "./components/ConnectionSettings";
-import { ThemeProvider } from "./theme/ThemeProvider";
+import { CurrentContextChain } from "./components/CurrentContextChain";
+import { CurrentPipeline } from "./components/CurrentPipeline";
+import { Events } from "./components/Events";
 import { GridLayout } from "./components/GridLayout";
-import { Box, Typography, AppBar, Toolbar } from "@mui/material";
-import { useState, useEffect } from "react";
+import { useMonitorSocket } from "./hooks/useMonitorSocket";
+import { ThemeProvider } from "./theme/ThemeProvider";
 
 function App() {
   const { connected, agentState, events, url, setUrl } = useMonitorSocket();

--- a/maiar-client/src/components/AgentStatus.tsx
+++ b/maiar-client/src/components/AgentStatus.tsx
@@ -1,5 +1,6 @@
-import { Box, Grid, Typography } from "@mui/material";
 import { FC } from "react";
+
+import { Box, Grid, Typography } from "@mui/material";
 
 interface AgentStatusProps {
   agentState?: {

--- a/maiar-client/src/components/Chat.tsx
+++ b/maiar-client/src/components/Chat.tsx
@@ -1,20 +1,22 @@
-import { useState, useRef, useEffect } from "react";
-import {
-  Paper,
-  Box,
-  Typography,
-  TextField,
-  IconButton,
-  Stack,
-  alpha,
-  Popover,
-  Button
-} from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+
+import RefreshIcon from "@mui/icons-material/Refresh";
 import SendIcon from "@mui/icons-material/Send";
 import SettingsIcon from "@mui/icons-material/Settings";
-import RefreshIcon from "@mui/icons-material/Refresh";
-import { useChatApi } from "../hooks/useChatApi";
+import {
+  alpha,
+  Box,
+  Button,
+  IconButton,
+  Paper,
+  Popover,
+  Stack,
+  TextField,
+  Typography
+} from "@mui/material";
+
 import { DEFAULT_URLS } from "../config";
+import { useChatApi } from "../hooks/useChatApi";
 
 interface Message {
   content: string;

--- a/maiar-client/src/components/ConnectionSettings.tsx
+++ b/maiar-client/src/components/ConnectionSettings.tsx
@@ -1,18 +1,20 @@
 import { useState } from "react";
+
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import SaveIcon from "@mui/icons-material/Save";
+import SettingsIcon from "@mui/icons-material/Settings";
 import {
   Box,
   Button,
   Chip,
+  IconButton,
+  InputAdornment,
   Popover,
   TextField,
-  Typography,
-  InputAdornment,
-  IconButton
+  Typography
 } from "@mui/material";
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-import SettingsIcon from "@mui/icons-material/Settings";
-import RefreshIcon from "@mui/icons-material/Refresh";
-import SaveIcon from "@mui/icons-material/Save";
+
 import { DEFAULT_URLS } from "../config";
 
 interface ConnectionSettingsProps {

--- a/maiar-client/src/components/CurrentContextChain.tsx
+++ b/maiar-client/src/components/CurrentContextChain.tsx
@@ -1,13 +1,14 @@
-import { Paper, Typography, Box } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+
 import {
   Timeline,
-  TimelineItem,
-  TimelineSeparator,
   TimelineConnector,
   TimelineContent,
-  TimelineDot
+  TimelineDot,
+  TimelineItem,
+  TimelineSeparator
 } from "@mui/lab";
-import { useState, useEffect, useRef } from "react";
+import { Box, Paper, Typography } from "@mui/material";
 
 interface BaseContextItem {
   id: string;

--- a/maiar-client/src/components/CurrentPipeline.tsx
+++ b/maiar-client/src/components/CurrentPipeline.tsx
@@ -1,6 +1,8 @@
-import { Paper, Typography, Box } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+
+import { Box, Paper, Typography } from "@mui/material";
+
 import { PipelineSteps } from "./PipelineSteps";
-import { useRef, useEffect, useState } from "react";
 
 interface CurrentPipelineProps {
   pipeline?: Array<{ pluginId: string; action: string }>;

--- a/maiar-client/src/components/EventFilter.tsx
+++ b/maiar-client/src/components/EventFilter.tsx
@@ -1,16 +1,17 @@
+import { useEffect, useState } from "react";
+
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import FilterListIcon from "@mui/icons-material/FilterList";
 import {
+  alpha,
   Box,
-  TextField,
-  Typography,
+  Chip,
   IconButton,
   Popover,
-  Chip,
-  alpha,
-  Tooltip
+  TextField,
+  Tooltip,
+  Typography
 } from "@mui/material";
-import FilterListIcon from "@mui/icons-material/FilterList";
-import AccessTimeIcon from "@mui/icons-material/AccessTime";
-import { useState, useEffect } from "react";
 
 interface EventFilterProps {
   onFilterChange: (filter: string) => void;

--- a/maiar-client/src/components/Events.tsx
+++ b/maiar-client/src/components/Events.tsx
@@ -1,7 +1,9 @@
-import { Box, Typography, Paper, Stack, alpha } from "@mui/material";
-import { useRef, useEffect, useState, useMemo } from "react";
-import JsonView from "./JsonView";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { alpha, Box, Paper, Stack, Typography } from "@mui/material";
+
 import { EventFilter } from "./EventFilter";
+import JsonView from "./JsonView";
 
 interface Event {
   type: string;

--- a/maiar-client/src/components/GridLayout.tsx
+++ b/maiar-client/src/components/GridLayout.tsx
@@ -1,18 +1,19 @@
-import { ReactNode, useState, useEffect, useRef, useCallback } from "react";
-import { Responsive, Layout } from "react-grid-layout";
-// CSS is imported in index.html
-import {
-  Box,
-  Paper,
-  Typography,
-  IconButton,
-  useTheme,
-  alpha,
-  Button,
-  Tooltip
-} from "@mui/material";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { Layout, Responsive } from "react-grid-layout";
+
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
+// CSS is imported in index.html
+import {
+  alpha,
+  Box,
+  Button,
+  IconButton,
+  Paper,
+  Tooltip,
+  Typography,
+  useTheme
+} from "@mui/material";
 
 // Create a custom responsive grid layout
 const ResponsiveGridLayout = Responsive;

--- a/maiar-client/src/components/JsonView.tsx
+++ b/maiar-client/src/components/JsonView.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, alpha, Chip } from "@mui/material";
+import { alpha, Box, Chip, Typography } from "@mui/material";
 
 interface JsonViewProps {
   data: unknown;

--- a/maiar-client/src/components/PipelineSteps.tsx
+++ b/maiar-client/src/components/PipelineSteps.tsx
@@ -1,13 +1,13 @@
-import { Paper, Stack, Chip, Typography, Box, alpha } from "@mui/material";
-import { styled, Theme } from "@mui/material/styles";
 import {
   Timeline,
-  TimelineItem,
+  TimelineConnector,
   TimelineContent,
-  TimelineSeparator,
   TimelineDot,
-  TimelineConnector
+  TimelineItem,
+  TimelineSeparator
 } from "@mui/lab";
+import { alpha, Box, Chip, Paper, Stack, Typography } from "@mui/material";
+import { styled, Theme } from "@mui/material/styles";
 
 interface PipelineStep {
   pluginId: string;

--- a/maiar-client/src/hooks/useChatApi.ts
+++ b/maiar-client/src/hooks/useChatApi.ts
@@ -1,4 +1,5 @@
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
+
 import { DEFAULT_URLS, STORAGE_KEYS } from "../config";
 
 interface UseChatApiOptions {

--- a/maiar-client/src/hooks/useMonitorSocket.ts
+++ b/maiar-client/src/hooks/useMonitorSocket.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
 import { DEFAULT_URLS, STORAGE_KEYS } from "../config";
 
 // Types from the monitor

--- a/maiar-client/src/main.tsx
+++ b/maiar-client/src/main.tsx
@@ -1,7 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "./index.css";
+
 import App from "./App.tsx";
+import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/maiar-client/src/theme/ThemeProvider.tsx
+++ b/maiar-client/src/theme/ThemeProvider.tsx
@@ -1,12 +1,12 @@
-import {
-  createTheme,
-  ThemeProvider as MuiThemeProvider
-} from "@mui/material/styles";
-import CssBaseline from "@mui/material/CssBaseline";
 import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
+import CssBaseline from "@mui/material/CssBaseline";
+import {
+  createTheme,
+  ThemeProvider as MuiThemeProvider
+} from "@mui/material/styles";
 
 const theme = createTheme({
   palette: {

--- a/maiar-client/vite.config.ts
+++ b/maiar-client/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+
 import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/

--- a/maiar-starter/src/express-app.ts
+++ b/maiar-starter/src/express-app.ts
@@ -1,10 +1,12 @@
+import cors from "cors";
+import { NextFunction, Response, Router } from "express";
+
 import { UserInputContext } from "@maiar-ai/core";
+
 import {
   ExpressPlatformContext,
   ExpressRequest
 } from "@maiar-ai/plugin-express";
-import { NextFunction, Response, Router } from "express";
-import cors from "cors";
 
 const router = Router();
 

--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -1,44 +1,50 @@
 import "dotenv/config";
 
-// Suppress deprecation warnings
-process.removeAllListeners("warning");
-
 import { config } from "dotenv";
 import fs from "fs";
 import path from "path";
 
-// Load environment variables from root .env
-config({
-  path: path.resolve(__dirname, "../../..", ".env")
-});
-
 import { createRuntime } from "@maiar-ai/core";
 
-// Import providers
-import { PostgresProvider } from "@maiar-ai/memory-postgres";
+// Import model providers
 import {
   OpenAIImageGenerationModel,
   OpenAIProvider,
   OpenAITextGenerationModel
 } from "@maiar-ai/model-openai";
-import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
+
+// Import memory provider
+import { PostgresProvider } from "@maiar-ai/memory-postgres";
+
+// Import monitor providers
 import { ConsoleMonitorProvider } from "@maiar-ai/monitor-console";
-// Import all plugins
+import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
+
+// Import plugins
 import { PluginCharacter } from "@maiar-ai/plugin-character";
+import { PluginDiscord } from "@maiar-ai/plugin-discord";
+import { PluginExpress } from "@maiar-ai/plugin-express";
+import { PluginImageGeneration } from "@maiar-ai/plugin-image";
 import { PluginSearch } from "@maiar-ai/plugin-search";
 import { PluginTerminal } from "@maiar-ai/plugin-terminal";
 import { PluginTextGeneration } from "@maiar-ai/plugin-text";
 import { PluginTime } from "@maiar-ai/plugin-time";
-import { PluginPermissionsSearch } from "./plugins/plugin-permissions-search";
-import { PluginExpress } from "@maiar-ai/plugin-express";
 import {
   createPostExecutor,
   periodicPostTrigger,
   PluginX
 } from "@maiar-ai/plugin-x";
-import { PluginImageGeneration } from "@maiar-ai/plugin-image";
+
 import { router } from "./express-app";
-import { PluginDiscord } from "@maiar-ai/plugin-discord";
+import { PluginPermissionsSearch } from "./plugins/plugin-permissions-search";
+
+// Suppress deprecation warnings
+process.removeAllListeners("warning");
+
+// Load environment variables from root .env
+config({
+  path: path.resolve(__dirname, "../../..", ".env")
+});
 
 // Create and start the agent
 const runtime = createRuntime({

--- a/maiar-starter/src/plugins/plugin-permissions-search/index.ts
+++ b/maiar-starter/src/plugins/plugin-permissions-search/index.ts
@@ -1,8 +1,8 @@
 import {
-  PluginBase,
   AgentContext,
-  PluginResult,
-  getUserInput
+  getUserInput,
+  PluginBase,
+  PluginResult
 } from "@maiar-ai/core";
 
 interface PermissionsSearchConfig {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@commitlint/format": "19.5.0",
     "@commitlint/types": "19.5.0",
     "@eslint/js": "9.19.0",
+    "@trivago/prettier-plugin-sort-imports": "5.2.2",
     "@types/node": "22.13.1",
     "chokidar-cli": "3.0.0",
     "commitizen": "4.3.1",

--- a/packages/core/src/memory/service.ts
+++ b/packages/core/src/memory/service.ts
@@ -1,3 +1,4 @@
+import { BaseContextItem } from "../types/agent";
 import { createLogger } from "../utils/logger";
 import {
   Context,
@@ -6,7 +7,6 @@ import {
   MemoryQueryOptions,
   Message
 } from "./types";
-import { BaseContextItem } from "../types/agent";
 
 const log = createLogger("memory");
 

--- a/packages/core/src/models/base.ts
+++ b/packages/core/src/models/base.ts
@@ -1,6 +1,6 @@
+import { MonitorService } from "../monitor/service";
 import { logModelInteraction } from "../utils/logger";
 import { ModelCapability } from "./capabilities";
-import { MonitorService } from "../monitor/service";
 import { ICapabilities } from "./types";
 
 /**

--- a/packages/core/src/models/capabilities.ts
+++ b/packages/core/src/models/capabilities.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+
 import { OperationConfig } from "../operations/base";
 
 /**

--- a/packages/core/src/models/service.ts
+++ b/packages/core/src/models/service.ts
@@ -1,7 +1,7 @@
-import { ModelProvider } from "./base";
-import { createLogger } from "../utils/logger";
-import { CapabilityRegistry, ModelCapability } from "./capabilities";
 import { OperationConfig } from "../operations/base";
+import { createLogger } from "../utils/logger";
+import { ModelProvider } from "./base";
+import { CapabilityRegistry, ModelCapability } from "./capabilities";
 import { ICapabilities } from "./types";
 
 const log = createLogger("models");

--- a/packages/core/src/operations/base.ts
+++ b/packages/core/src/operations/base.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+
 import { ModelRequestConfig } from "../models/base";
 import { ModelProvider } from "../models/base";
 

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -1,5 +1,5 @@
-import { AgentContext } from "../types/agent";
 import { Runtime } from "../runtime";
+import { AgentContext } from "../types/agent";
 
 /**
  * Result of a plugin execution

--- a/packages/core/src/plugin/types.ts
+++ b/packages/core/src/plugin/types.ts
@@ -1,5 +1,5 @@
-import { AgentContext } from "../types/agent";
 import { Runtime } from "../runtime";
+import { AgentContext } from "../types/agent";
 
 /**
  * Result of a plugin execution

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -1,6 +1,6 @@
 import { Plugin } from "../plugin";
-import { PluginRegistryInterface } from "./types";
 import { createLogger } from "../utils/logger";
+import { PluginRegistryInterface } from "./types";
 
 const log = createLogger("plugins");
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,42 +1,43 @@
 import { z } from "zod";
+
+import { MemoryService } from "../memory/service";
+import { LoggingModelDecorator, ModelRequestConfig } from "../models/base";
+import { ModelService } from "../models/service";
+import { ICapabilities } from "../models/types";
+import { MonitorService } from "../monitor/service";
+import { formatZodSchema, OperationConfig } from "../operations/base";
 import { Plugin } from "../plugin";
 import { PluginRegistry } from "../registry";
 import {
   AgentContext,
-  EventQueue,
-  UserInputContext,
   BaseContextItem,
-  getUserInput
+  EventQueue,
+  getUserInput,
+  UserInputContext
 } from "../types/agent";
+import { createLogger, logPipelineState } from "../utils/logger";
 import {
-  PipelineSchema,
-  PipelineStep,
+  cleanJsonString,
+  extractJson,
+  generateObjectTemplate,
+  generatePipelineModificationTemplate,
+  generatePipelineTemplate,
+  generateRetryTemplate
+} from "./templates";
+import {
+  ContextItemWithHistory,
+  ErrorContextItem,
+  GetObjectConfig,
   Pipeline,
   PipelineGenerationContext,
-  PipelineModificationContext,
   PipelineModification,
+  PipelineModificationContext,
   PipelineModificationSchema,
+  PipelineSchema,
+  PipelineStep,
   RuntimeConfig,
-  RuntimeOptions,
-  ErrorContextItem,
-  ContextItemWithHistory,
-  GetObjectConfig
+  RuntimeOptions
 } from "./types";
-import {
-  generatePipelineTemplate,
-  generatePipelineModificationTemplate,
-  generateObjectTemplate,
-  generateRetryTemplate,
-  cleanJsonString,
-  extractJson
-} from "./templates";
-import { ModelService } from "../models/service";
-import { createLogger, logPipelineState } from "../utils/logger";
-import { formatZodSchema, OperationConfig } from "../operations/base";
-import { MemoryService } from "../memory/service";
-import { MonitorService } from "../monitor/service";
-import { LoggingModelDecorator, ModelRequestConfig } from "../models/base";
-import { ICapabilities } from "../models/types";
 
 const log = createLogger("runtime");
 

--- a/packages/core/src/runtime/templates.ts
+++ b/packages/core/src/runtime/templates.ts
@@ -1,7 +1,7 @@
 import { TemplateFunction } from "../operations/base";
 import {
-  PipelineModificationContext,
-  PipelineGenerationContext
+  PipelineGenerationContext,
+  PipelineModificationContext
 } from "./types";
 
 interface ConversationMessage {

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -1,13 +1,15 @@
 import { z } from "zod";
-import { Plugin } from "../plugin";
+
 import { MemoryService } from "../memory/service";
 import { MemoryProvider } from "../memory/types";
 import { ModelProvider } from "../models/base";
 import { ModelService } from "../models/service";
-import { BaseContextItem } from "../types/agent";
 import { MonitorService } from "../monitor/service";
 import { MonitorProvider } from "../monitor/types";
 import { OperationConfig } from "../operations/base";
+import { Plugin } from "../plugin";
+import { BaseContextItem } from "../types/agent";
+
 /**
  * A step in the execution pipeline
  */

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,7 +1,8 @@
 import fs from "fs";
 import path from "path";
 import pino from "pino";
-import { PipelineStep, PipelineModification } from "../runtime/types";
+
+import { PipelineModification, PipelineStep } from "../runtime/types";
 import { BaseContextItem } from "../types/agent";
 
 // Ensure logs directory exists and clear model interactions log file
@@ -171,13 +172,13 @@ const pipelineLogger = pino(
         const pipeline = object.currentPipeline as PipelineStep[] | undefined;
         const executed = object.executedStep as
           | {
-            step: PipelineStep;
-            result: {
-              success: boolean;
-              error?: string;
-              data?: unknown;
-            };
-          }
+              step: PipelineStep;
+              result: {
+                success: boolean;
+                error?: string;
+                data?: unknown;
+              };
+            }
           | undefined;
         const execContextChain = object.contextChain as
           | BaseContextItem[]

--- a/packages/memory-filesystem/src/provider.ts
+++ b/packages/memory-filesystem/src/provider.ts
@@ -3,11 +3,11 @@ import path from "path";
 
 import { createLogger } from "@maiar-ai/core";
 import {
-  MemoryProvider,
-  Message,
   Context,
   Conversation,
-  MemoryQueryOptions
+  MemoryProvider,
+  MemoryQueryOptions,
+  Message
 } from "@maiar-ai/core";
 
 const log = createLogger("memory:filesystem");

--- a/packages/memory-postgres/src/provider.ts
+++ b/packages/memory-postgres/src/provider.ts
@@ -1,11 +1,12 @@
 import { Pool } from "pg";
+
 import { createLogger } from "@maiar-ai/core";
 import {
-  MemoryProvider,
-  Message,
   Context,
   Conversation,
-  MemoryQueryOptions
+  MemoryProvider,
+  MemoryQueryOptions,
+  Message
 } from "@maiar-ai/core";
 
 const log = createLogger("memory:postgres");

--- a/packages/memory-sqlite/src/provider.ts
+++ b/packages/memory-sqlite/src/provider.ts
@@ -1,16 +1,14 @@
+import Database from "better-sqlite3";
 import fs from "fs";
 import path from "path";
 
-import Database from "better-sqlite3";
-
 import { createLogger } from "@maiar-ai/core";
-
 import {
-  MemoryProvider,
-  Message,
   Context,
   Conversation,
-  MemoryQueryOptions
+  MemoryProvider,
+  MemoryQueryOptions,
+  Message
 } from "@maiar-ai/core";
 
 const log = createLogger("memory:sqlite");

--- a/packages/model-ollama/src/deepseek.ts
+++ b/packages/model-ollama/src/deepseek.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
+
 import { ModelProviderBase, ModelRequestConfig } from "@maiar-ai/core";
 import { createLogger } from "@maiar-ai/core";
+
 import { verifyBasicHealth } from "./index";
 
 const log = createLogger("models");

--- a/packages/model-ollama/src/ollama.ts
+++ b/packages/model-ollama/src/ollama.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
+
 import { ModelProviderBase, ModelRequestConfig } from "@maiar-ai/core";
 import { createLogger } from "@maiar-ai/core";
+
 import { verifyBasicHealth } from "./index";
 
 const log = createLogger("model:ollama");

--- a/packages/model-openai/src/openai.ts
+++ b/packages/model-openai/src/openai.ts
@@ -1,24 +1,24 @@
+import OpenAI from "openai";
 import { z } from "zod";
 
-import OpenAI from "openai";
 import {
   ModelProviderBase,
   ModelRequestConfig,
   MonitorService
 } from "@maiar-ai/core";
-import {
-  OpenAIModelRequestConfig,
-  OpenAITextGenerationModel,
-  OpenAIImageGenerationModel,
-  OpenAIModel,
-  OpenAIConfig,
-  textGenerationSchema,
-  imageGenerationSchema
-} from "./types";
 
 import {
-  TEXT_GENERATION_CAPABILITY_ID,
-  IMAGE_GENERATION_CAPABILITY_ID
+  imageGenerationSchema,
+  OpenAIConfig,
+  OpenAIImageGenerationModel,
+  OpenAIModel,
+  OpenAIModelRequestConfig,
+  OpenAITextGenerationModel,
+  textGenerationSchema
+} from "./types";
+import {
+  IMAGE_GENERATION_CAPABILITY_ID,
+  TEXT_GENERATION_CAPABILITY_ID
 } from "./types";
 
 // Helper functions to check model types

--- a/packages/model-openai/src/types.ts
+++ b/packages/model-openai/src/types.ts
@@ -1,5 +1,6 @@
-import { ModelRequestConfig } from "@maiar-ai/core";
 import { z } from "zod";
+
+import { ModelRequestConfig } from "@maiar-ai/core";
 
 export const TEXT_GENERATION_CAPABILITY_ID = "text-generation";
 export const IMAGE_GENERATION_CAPABILITY_ID = "image-generation";

--- a/packages/monitor-websocket/src/provider.ts
+++ b/packages/monitor-websocket/src/provider.ts
@@ -1,4 +1,5 @@
-import { WebSocketServer, WebSocket } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
+
 import { MonitorProvider } from "@maiar-ai/core";
 
 /**

--- a/packages/plugin-character/src/plugin.ts
+++ b/packages/plugin-character/src/plugin.ts
@@ -1,4 +1,5 @@
 import { createLogger, PluginBase, PluginResult } from "@maiar-ai/core";
+
 import { CharacterPluginConfig } from "./types";
 
 const log = createLogger("plugin:character");

--- a/packages/plugin-discord/src/plugin.ts
+++ b/packages/plugin-discord/src/plugin.ts
@@ -1,4 +1,12 @@
 import {
+  BaseGuildTextChannel,
+  Client,
+  Events,
+  GatewayIntentBits,
+  Message
+} from "discord.js";
+
+import {
   AgentContext,
   createLogger,
   MonitorService,
@@ -7,27 +15,21 @@ import {
   Runtime,
   UserInputContext
 } from "@maiar-ai/core";
+
 import {
-  Client,
-  Events,
-  GatewayIntentBits,
-  Message,
-  BaseGuildTextChannel
-} from "discord.js";
+  generateChannelSelectionTemplate,
+  generateMessageIntentTemplate,
+  generateResponseTemplate
+} from "./templates";
 import {
+  ChannelInfo,
+  DiscordChannelSelectionSchema,
+  DiscordPlatformContext,
   DiscordPluginConfig,
   DiscordReplySchema,
   DiscordSendSchema,
-  DiscordChannelSelectionSchema,
-  ChannelInfo,
-  MessageIntentSchema,
-  DiscordPlatformContext
+  MessageIntentSchema
 } from "./types";
-import {
-  generateResponseTemplate,
-  generateChannelSelectionTemplate,
-  generateMessageIntentTemplate
-} from "./templates";
 
 const log = createLogger("plugin:discord");
 

--- a/packages/plugin-discord/src/templates.ts
+++ b/packages/plugin-discord/src/templates.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-useless-escape */
 import { BaseContextItem } from "@maiar-ai/core";
+
 import { ChannelInfo } from "./types";
 
 export function generateResponseTemplate(

--- a/packages/plugin-discord/src/types.ts
+++ b/packages/plugin-discord/src/types.ts
@@ -1,5 +1,6 @@
-import { AgentContext } from "@maiar-ai/core";
 import { z } from "zod";
+
+import { AgentContext } from "@maiar-ai/core";
 
 export interface DiscordPlatformContext
   extends NonNullable<AgentContext["platformContext"]> {

--- a/packages/plugin-express/src/plugin.ts
+++ b/packages/plugin-express/src/plugin.ts
@@ -1,6 +1,7 @@
 import express, { Express, Request, Response } from "express";
 
 import { PluginBase, PluginResult } from "@maiar-ai/core";
+
 import { generateResponseTemplate } from "./templates";
 import {
   ExpressPluginConfig,

--- a/packages/plugin-express/src/types.ts
+++ b/packages/plugin-express/src/types.ts
@@ -1,5 +1,6 @@
 import { Request, Router } from "express";
 import { z } from "zod";
+
 import { PluginExpress } from "./plugin";
 
 /**

--- a/packages/plugin-image/src/plugin.ts
+++ b/packages/plugin-image/src/plugin.ts
@@ -1,6 +1,7 @@
-import { PluginBase, AgentContext, PluginResult } from "@maiar-ai/core";
-import { IMAGE_GENERATION_CAPABILITY_ID, PromptResponseSchema } from "./types";
+import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
+
 import { generatePromptTemplate } from "./templates";
+import { IMAGE_GENERATION_CAPABILITY_ID, PromptResponseSchema } from "./types";
 
 export class PluginImageGeneration extends PluginBase {
   constructor() {

--- a/packages/plugin-search/src/plugin.ts
+++ b/packages/plugin-search/src/plugin.ts
@@ -1,7 +1,8 @@
 import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
-import { PerplexityQueryResponseSchema, SearchPluginConfig } from "./types";
-import { generateQueryTemplate } from "./templates";
+
 import { PerplexityService } from "./perplexity";
+import { generateQueryTemplate } from "./templates";
+import { PerplexityQueryResponseSchema, SearchPluginConfig } from "./types";
 
 export class PluginSearch extends PluginBase {
   private service: PerplexityService;

--- a/packages/plugin-telegram/src/plugin.ts
+++ b/packages/plugin-telegram/src/plugin.ts
@@ -1,19 +1,19 @@
 import { Telegraf } from "telegraf";
 
 import {
-  PluginBase,
   AgentContext,
+  PluginBase,
   PluginResult,
   Runtime
 } from "@maiar-ai/core";
 import { createLogger } from "@maiar-ai/core";
 
-import {
-  TelegramPluginConfig,
-  TelegramResponseSchema,
-  TelegramContext
-} from "./types";
 import { generateResponseTemplate } from "./templates";
+import {
+  TelegramContext,
+  TelegramPluginConfig,
+  TelegramResponseSchema
+} from "./types";
 
 const log = createLogger("plugin:telegram");
 

--- a/packages/plugin-telegram/src/types.ts
+++ b/packages/plugin-telegram/src/types.ts
@@ -1,5 +1,6 @@
 import { Composer, Context } from "telegraf";
 import { z } from "zod";
+
 import { PluginTelegram } from "./plugin";
 
 export interface TelegramPlatformContext {

--- a/packages/plugin-terminal/src/plugin.ts
+++ b/packages/plugin-terminal/src/plugin.ts
@@ -1,9 +1,11 @@
-import { PluginBase, PluginResult, UserInputContext } from "@maiar-ai/core";
-import { TerminalPluginConfig, TerminalResponseSchema } from "./types";
-import * as net from "net";
 import * as fs from "fs";
-import { generateResponseTemplate } from "./templates";
+import * as net from "net";
+
+import { PluginBase, PluginResult, UserInputContext } from "@maiar-ai/core";
+
 import { CHAT_SOCKET_PATH } from "./index";
+import { generateResponseTemplate } from "./templates";
+import { TerminalPluginConfig, TerminalResponseSchema } from "./types";
 
 interface TerminalPlatformContext {
   platform: string;

--- a/packages/plugin-terminal/src/scripts/chat.ts
+++ b/packages/plugin-terminal/src/scripts/chat.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-
-import * as readline from "readline";
-import * as net from "net";
 import chalk from "chalk";
+import * as net from "net";
+import * as readline from "readline";
+
 import { CHAT_SOCKET_PATH } from "../index";
 import { TerminalPluginConfig } from "../types";
 

--- a/packages/plugin-terminal/tsup.config.ts
+++ b/packages/plugin-terminal/tsup.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "tsup";
 import { chmod } from "fs/promises";
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {

--- a/packages/plugin-text/src/plugin.ts
+++ b/packages/plugin-text/src/plugin.ts
@@ -1,10 +1,11 @@
 import {
-  PluginBase,
   AgentContext,
-  PluginResult,
   BaseContextItem,
-  getUserInput
+  getUserInput,
+  PluginBase,
+  PluginResult
 } from "@maiar-ai/core";
+
 import { generateTextTemplate } from "./templates";
 import { TEXT_GENERATION_CAPABILITY_ID } from "./types";
 

--- a/packages/plugin-websocket/src/plugin.ts
+++ b/packages/plugin-websocket/src/plugin.ts
@@ -1,7 +1,9 @@
 import WebSocket, { WebSocketServer } from "ws";
+import { RawData } from "ws";
+
 import { PluginBase } from "@maiar-ai/core";
 import { Runtime, UserInputContext } from "@maiar-ai/core";
-import { RawData } from "ws";
+
 import { WebSocketPluginConfig } from "./types";
 
 interface WebSocketPlatformContext {

--- a/packages/plugin-x/src/executors.ts
+++ b/packages/plugin-x/src/executors.ts
@@ -4,9 +4,10 @@ import {
   PluginResult,
   Runtime
 } from "@maiar-ai/core";
+
 import { XService } from "./services";
-import { PostTweetSchema, TweetOptions, XExecutorFactory } from "./types";
 import { generateTweetTemplate } from "./templates";
+import { PostTweetSchema, TweetOptions, XExecutorFactory } from "./types";
 
 /**
  * Creates an executor with a bound XService and Runtime instance

--- a/packages/plugin-x/src/plugin.ts
+++ b/packages/plugin-x/src/plugin.ts
@@ -1,21 +1,23 @@
+import * as path from "path";
+
 import {
-  PluginBase,
   ExecutorImplementation,
-  Trigger,
+  MonitorService,
+  PluginBase,
   Runtime,
-  MonitorService
+  Trigger
 } from "@maiar-ai/core";
+
+import { createAllCustomExecutors } from "./executors";
+import { runAuthFlow } from "./scripts/auth-flow";
+import { TokenStorage, XService } from "./services";
+import { createAllCustomTriggers } from "./triggers";
 import {
-  XPluginConfig,
-  XExecutorFactory,
   TriggerConfig,
+  XExecutorFactory,
+  XPluginConfig,
   XTriggerFactory
 } from "./types";
-import { XService, TokenStorage } from "./services";
-import { runAuthFlow } from "./scripts/auth-flow";
-import * as path from "path";
-import { createAllCustomExecutors } from "./executors";
-import { createAllCustomTriggers } from "./triggers";
 
 export class PluginX extends PluginBase {
   private xService: XService;

--- a/packages/plugin-x/src/scripts/auth-flow.ts
+++ b/packages/plugin-x/src/scripts/auth-flow.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+// Load environment variables from .env file
+import "dotenv/config";
 
-import "dotenv/config"; // Load environment variables from .env file
-import { XService, TokenStorage } from "../services";
-import * as readline from "readline";
 import * as path from "path";
+import * as readline from "readline";
+
+import { TokenStorage, XService } from "../services";
 
 /**
  * Interactive script that guides you through the complete X API auth flow

--- a/packages/plugin-x/src/services/token-storage.ts
+++ b/packages/plugin-x/src/services/token-storage.ts
@@ -1,6 +1,7 @@
-import { XOAuthToken } from "../types";
 import * as fs from "fs/promises";
 import * as path from "path";
+
+import { XOAuthToken } from "../types";
 
 /**
  * Token storage service for X API OAuth tokens

--- a/packages/plugin-x/src/services/x-service.ts
+++ b/packages/plugin-x/src/services/x-service.ts
@@ -1,6 +1,7 @@
-import { XOAuthToken, TweetOptions } from "../types";
 import * as crypto from "crypto";
 import * as path from "path";
+
+import { TweetOptions, XOAuthToken } from "../types";
 
 // Twitter API v2 Base URL
 const API_BASE_URL = "https://api.twitter.com/2";

--- a/packages/plugin-x/src/triggers.ts
+++ b/packages/plugin-x/src/triggers.ts
@@ -1,9 +1,10 @@
-import { Trigger, UserInputContext, Runtime } from "@maiar-ai/core";
-import { XService } from "./services";
+import { Runtime, Trigger, UserInputContext } from "@maiar-ai/core";
 import { createLogger } from "@maiar-ai/core";
+import { MonitorService } from "@maiar-ai/core";
+
+import { XService } from "./services";
 import { xPostTemplate } from "./templates";
 import { TriggerConfig, XTriggerFactory } from "./types";
-import { MonitorService } from "@maiar-ai/core";
 
 const log = createLogger("plugin-x:periodic-post-trigger");
 

--- a/packages/plugin-x/src/types.ts
+++ b/packages/plugin-x/src/types.ts
@@ -1,8 +1,11 @@
+import { z } from "zod";
+
 import { AgentContext } from "@maiar-ai/core";
 import { ExecutorImplementation, Trigger } from "@maiar-ai/core";
-import { XService } from "./services";
 import { Runtime } from "@maiar-ai/core";
-import { z } from "zod";
+
+import { XService } from "./services";
+
 /**
  * Configuration for the X plugin
  */

--- a/packages/plugin-x/tsup.config.ts
+++ b/packages/plugin-x/tsup.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "tsup";
 import { chmod } from "fs/promises";
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       "@eslint/js":
         specifier: 9.19.0
         version: 9.19.0
+      "@trivago/prettier-plugin-sort-imports":
+        specifier: 5.2.2
+        version: 5.2.2(prettier@3.4.2)
       "@types/node":
         specifier: 22.13.1
         version: 22.13.1
@@ -4288,6 +4291,25 @@ packages:
       {
         integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==
       }
+
+  "@trivago/prettier-plugin-sort-imports@5.2.2":
+    resolution:
+      {
+        integrity: sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==
+      }
+    engines: { node: ">18.12" }
+    peerDependencies:
+      "@vue/compiler-sfc": 3.x
+      prettier: 2.x - 3.x
+      prettier-plugin-svelte: 3.x
+      svelte: 4.x || 5.x
+    peerDependenciesMeta:
+      "@vue/compiler-sfc":
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      svelte:
+        optional: true
 
   "@trysound/sax@0.2.0":
     resolution:
@@ -9094,6 +9116,12 @@ packages:
       }
     engines: { node: ">=10" }
     hasBin: true
+
+  javascript-natural-sort@0.7.1:
+    resolution:
+      {
+        integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
+      }
 
   jest-diff@29.7.0:
     resolution:
@@ -18142,6 +18170,18 @@ snapshots:
 
   "@telegraf/types@7.1.0": {}
 
+  "@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.4.2)":
+    dependencies:
+      "@babel/generator": 7.26.5
+      "@babel/parser": 7.26.7
+      "@babel/traverse": 7.26.7
+      "@babel/types": 7.26.7
+      javascript-natural-sort: 0.7.1
+      lodash: 4.17.21
+      prettier: 3.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   "@trysound/sax@0.2.0": {}
 
   "@tufjs/canonical-json@2.0.0": {}
@@ -21243,6 +21283,8 @@ snapshots:
       chalk: 4.1.2
       filelist: 1.0.4
       minimatch: 3.1.2
+
+  javascript-natural-sort@0.7.1: {}
 
   jest-diff@29.7.0:
     dependencies:

--- a/restart.js
+++ b/restart.js
@@ -1,5 +1,5 @@
-import fs from "fs";
 import { spawn } from "child_process";
+import fs from "fs";
 
 const pidFile = ".pid";
 

--- a/website/docs/01-building-plugins/02-executors.md
+++ b/website/docs/01-building-plugins/02-executors.md
@@ -273,8 +273,10 @@ execute: async (context: AgentContext): Promise<PluginResult> => {
 Here's a complete example of an image generation plugin:
 
 ```typescript
-import { PluginBase, PluginResult, AgentContext } from "@maiar-ai/core";
 import { z } from "zod";
+
+import { AgentContext, PluginBase, PluginResult } from "@maiar-ai/core";
+
 import { ImageService } from "./service";
 import { generatePromptTemplate } from "./templates";
 

--- a/website/docs/03-memory-providers/01-overview.md
+++ b/website/docs/03-memory-providers/01-overview.md
@@ -53,7 +53,8 @@ Let's look at our SQLite implementation as an example. It demonstrates how to im
 
 ```typescript
 import Database from "better-sqlite3";
-import { MemoryProvider, Message, Context, Conversation } from "@maiar-ai/core";
+
+import { Context, Conversation, MemoryProvider, Message } from "@maiar-ai/core";
 import { createLogger } from "@maiar-ai/core";
 
 const log = createLogger("memory:sqlite");

--- a/website/docs/04-monitor-providers/01-overview.md
+++ b/website/docs/04-monitor-providers/01-overview.md
@@ -53,6 +53,7 @@ One of the strengths of MAIAR's monitoring system is the ability to use multiple
 ```typescript
 import { ConsoleMonitorProvider } from "@maiar-ai/monitor-console";
 import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
+
 import { CustomMonitorProvider } from "./custom-monitor";
 
 const runtime = createRuntime({

--- a/website/docs/04-monitor-providers/02-console-monitor.md
+++ b/website/docs/04-monitor-providers/02-console-monitor.md
@@ -39,6 +39,7 @@ Integrating the Console Monitor into your agent is straightforward:
 
 ```typescript
 import { createRuntime } from "@maiar-ai/core";
+
 import { ConsoleMonitorProvider } from "@maiar-ai/monitor-console";
 
 const runtime = createRuntime({

--- a/website/docs/04-monitor-providers/03-websocket-monitor.md
+++ b/website/docs/04-monitor-providers/03-websocket-monitor.md
@@ -43,6 +43,7 @@ Integrating the WebSocket Monitor into your agent:
 
 ```typescript
 import { createRuntime } from "@maiar-ai/core";
+
 import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
 
 const runtime = createRuntime({

--- a/website/docs/04-monitor-providers/05-maiar-client.md
+++ b/website/docs/04-monitor-providers/05-maiar-client.md
@@ -28,6 +28,7 @@ First, ensure your agent is configured to use the WebSocket Monitor:
 
 ```typescript
 import { createRuntime } from "@maiar-ai/core";
+
 import { WebSocketMonitorProvider } from "@maiar-ai/monitor-websocket";
 
 const runtime = createRuntime({

--- a/website/docs/05-core-utilities/createEvent.md
+++ b/website/docs/05-core-utilities/createEvent.md
@@ -207,8 +207,9 @@ class WebhookPlugin extends PluginBase {
 Here's a complete example of a trigger that uses createEvent:
 
 ```typescript
-import { PluginBase, AgentContext, Trigger } from "@maiar-ai/core";
 import { WebSocketServer } from "ws";
+
+import { AgentContext, PluginBase, Trigger } from "@maiar-ai/core";
 
 export class WebSocketPlugin extends PluginBase {
   private wss: WebSocketServer;

--- a/website/docs/05-core-utilities/getObject.md
+++ b/website/docs/05-core-utilities/getObject.md
@@ -175,6 +175,7 @@ Here's a complete example showing how to extract complex, nested data:
 
 ```typescript
 import { z } from "zod";
+
 import { Runtime } from "@maiar-ai/core";
 
 // Define a complex schema

--- a/website/docs/05-core-utilities/runtime.md
+++ b/website/docs/05-core-utilities/runtime.md
@@ -12,6 +12,7 @@ The simplest way to create a runtime is using the `createRuntime` function:
 
 ```typescript
 import { createRuntime } from "@maiar-ai/core";
+
 import { ModelProvider } from "@maiar-ai/model-ollama";
 
 const runtime = createRuntime({
@@ -174,10 +175,13 @@ Here's a complete example of setting up a runtime with multiple plugins and erro
 
 ```typescript
 import { createRuntime } from "@maiar-ai/core";
+
 import { ModelProvider } from "@maiar-ai/model-ollama";
+
 import { SQLiteMemoryProvider } from "@maiar-ai/memory-sqlite";
-import { PluginTerminal } from "@maiar-ai/plugin-terminal";
+
 import { PluginExpress } from "@maiar-ai/plugin-express";
+import { PluginTerminal } from "@maiar-ai/plugin-terminal";
 
 async function main() {
   try {

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -79,13 +79,18 @@ mkdir -p src
 
 ```typescript
 import "dotenv/config";
+
+import path from "path";
+
 import { createRuntime } from "@maiar-ai/core";
-import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
+
 import { OpenAIProvider } from "@maiar-ai/model-openai";
+
+import { SQLiteProvider } from "@maiar-ai/memory-sqlite";
+
 import { PluginTerminal } from "@maiar-ai/plugin-terminal";
 import { PluginTextGeneration } from "@maiar-ai/plugin-text";
 import { PluginTime } from "@maiar-ai/plugin-time";
-import path from "path";
 
 // Create and start the agent
 const runtime = createRuntime({

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,6 +1,6 @@
-import { themes as prismThemes } from "prism-react-renderer";
-import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
+import type { Config } from "@docusaurus/types";
+import { themes as prismThemes } from "prism-react-renderer";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 

--- a/website/src/components/AsciiLogo/index.tsx
+++ b/website/src/components/AsciiLogo/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import styles from "./styles.module.css";
+
 import { asciiLogo } from "./logo";
+import styles from "./styles.module.css";
 
 export function AsciiLogo() {
   return <pre className={styles.ascii}>{asciiLogo}</pre>;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef } from "react";
 import type { JSX } from "react";
+import GlitchClip from "react-glitch-effect/core/GlitchClip";
 
 import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
 
-import GlitchClip from "react-glitch-effect/core/GlitchClip";
 import { AsciiLogo } from "../components/AsciiLogo";
 
 export default function Home(): JSX.Element {

--- a/website/src/pages/plugins.tsx
+++ b/website/src/pages/plugins.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
+
 import Layout from "@theme/Layout";
 import clsx from "clsx";
+
 import styles from "../css/plugins.module.css";
 
 interface Plugin {


### PR DESCRIPTION
## Description

- Adds @trivago/prettier-plugin-sort-imports as a devDependency and configures prettier to use this plugin to sort imports
- Import sorting is declared in this order and is separated by a new line:
   - "dotenv/config",
   - "^react",
   - "^vite",
   - "<THIRD_PARTY_MODULES>",
   - "^@maiar-ai/core",
   - "^@maiar-ai/model(.*)$",
   - "^@maiar-ai/memory(.*)$",
   - "^@maiar-ai/monitor(.*)$",
   - "^@maiar-ai/plugin(.*)$",
   - "^[./]",
   - "^[../]"
- gh pre-commit hook runs prettier on every commit developers make so they will never have to worry about their import order

## Related Issues

- PRs have unnecessary diffs when adding, removing, or editing imports that causes bloat when reviewing PRs

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

1. Go to any typescript file and scramble up the imports
2. At the root dir level, run `pnpm prettier`
3. Observe your imports being sorted

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
