### PR TITLE
docs(website): add supported and non-supported wallets warning in bounties docs

### DIFF
--- a/website/docs/bounty-program.md
+++ b/website/docs/bounty-program.md
@@ -36,6 +36,18 @@ Our **GitHub Action-Based Bounty Program** is designed to **reward contributors 
    - The workflow comments on the PR with the **transaction signature** for confirmation.
    - The bounty issue(s) are then marked with the `bounty paid` label.
 
+:::warning Use a Valid Solana Wallet
+Please use a valid Solana wallet that supports token address creation to receive $MAIAR payments. We recommend using a non-custodial wallet like Phantom.
+
+Wallets confirmed to work:
+
+- Phantom
+
+Wallets confirmed to not work:
+
+- Bybit
+  :::
+
 ## Contributor Guidelines
 
 - **Issue Proposals**: Contributors can propose new issues, which the core team may assign a bounty to.


### PR DESCRIPTION
## Description
Adds a small blurb about supported and non supported wallets for our automatic bounty payments.

<img width="856" alt="image" src="https://github.com/user-attachments/assets/750f6172-05f4-47a2-86b9-7c7e63b0f067" />

## Related Issues
Issue was first encountered here. This is not a fix, only a way to prevent this issue until this is resolved: https://github.com/UraniumCorporation/maiar-ai/pull/71#issuecomment-2759381129

## Changes Made
- [x] Documentation updated

## Checklist
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
