### PR TITLE
fix: runtime getter resolves runtime undefined at executor mount

### DIFF
--- a/maiar-starter/src/index.ts
+++ b/maiar-starter/src/index.ts
@@ -79,15 +79,15 @@ async function main() {
       callback_url: process.env.X_CALLBACK_URL as string,
       // You can customize which executors and triggers to use
       // If not specified, all default ones will be used automatically
-      customExecutors: [createPostExecutor],
-      customTriggers: [periodicPostTrigger]
+      executorFactories: [createPostExecutor],
+      triggerFactories: [periodicPostTrigger]
     }),
     new DiscordPlugin({
       token: process.env.DISCORD_BOT_TOKEN as string,
       clientId: process.env.DISCORD_CLIENT_ID as string,
       commandPrefix: "!",
-      customExecutors: [sendMessageExecutor, replyMessageExecutor],
-      customTriggers: [postListenerTrigger]
+      executorFactories: [sendMessageExecutor, replyMessageExecutor],
+      triggerFactories: [postListenerTrigger]
     })
   ];
 

--- a/packages/plugin-discord/src/executors.ts
+++ b/packages/plugin-discord/src/executors.ts
@@ -35,10 +35,13 @@ export function discordExecutorFactory(
     scope: `plugin-discord`
   });
 
-  return (service: DiscordService, runtime: Runtime): Executor => ({
+  return (service: DiscordService, getRuntime: () => Runtime): Executor => ({
     name,
     description,
-    fn: (context: AgentContext) => execute(context, service, runtime, logger)
+    fn: (context: AgentContext) => {
+      const runtime = getRuntime();
+      return execute(context, service, runtime, logger);
+    }
   });
 }
 

--- a/packages/plugin-discord/src/plugin.ts
+++ b/packages/plugin-discord/src/plugin.ts
@@ -18,8 +18,8 @@ export class DiscordPlugin extends Plugin {
     clientId: string;
     commandPrefix?: string;
     guildId?: string;
-    customExecutors?: DiscordExecutorFactory[];
-    customTriggers?: DiscordTriggerFactory[];
+    executorFactories?: DiscordExecutorFactory[];
+    triggerFactories?: DiscordTriggerFactory[];
   }) {
     super({
       id: "plugin-discord",
@@ -34,8 +34,8 @@ export class DiscordPlugin extends Plugin {
     this.guildId = config.guildId;
     this.commandPrefix = config.commandPrefix || "!";
 
-    this.triggerFactories = config.customTriggers || [];
-    this.executorFactories = config.customExecutors || [];
+    this.triggerFactories = config.triggerFactories || [];
+    this.executorFactories = config.executorFactories || [];
 
     // initialize the discord service
     this.discordService = new DiscordService({
@@ -67,14 +67,16 @@ export class DiscordPlugin extends Plugin {
 
   private registerExecutors(): void {
     for (const executorFactory of this.executorFactories) {
-      this.executors.push(executorFactory(this.discordService, this.runtime));
+      this.executors.push(
+        executorFactory(this.discordService, () => this.runtime)
+      );
     }
   }
 
   private registerTriggers(): void {
     for (const triggerFactory of this.triggerFactories) {
       this.triggers.push(
-        triggerFactory(this.discordService, this.runtime, {
+        triggerFactory(this.discordService, () => this.runtime, {
           commandPrefix: this.commandPrefix
         })
       );

--- a/packages/plugin-discord/src/triggers.ts
+++ b/packages/plugin-discord/src/triggers.ts
@@ -21,13 +21,14 @@ import {
  */
 export const postListenerTrigger: DiscordTriggerFactory = (
   discordService: DiscordService,
-  runtime: Runtime
+  getRuntime: () => Runtime
 ) => {
   const logger = maiarLogger.default.child({
     scope: `plugin-discord`
   });
 
   async function handleMessage(message: Message): Promise<void> {
+    const runtime = getRuntime();
     // Skip bot messages
     if (message.author.bot) return;
 

--- a/packages/plugin-discord/src/types.ts
+++ b/packages/plugin-discord/src/types.ts
@@ -87,21 +87,33 @@ export const MessageIntentSchema = z.object({
 export type MessageIntent = z.infer<typeof MessageIntentSchema>;
 
 /**
- * Function that receives XService and returns an Executor
- * This allows for dependency injection of the XService
+ * Function that receives DiscordService and returns an Executor
+ * This allows for dependency injection of the DiscordService
  */
 export type DiscordExecutorFactory = (
+  /**
+   * The underlying Discord service
+   */
   service: DiscordService,
-  runtime: Runtime
+  /**
+   * Function that returns the plugins runtime
+   */
+  getRuntime: () => Runtime
 ) => Executor;
 
 /**
- * Function that receives XService and config and returns a Trigger
- * This allows for dependency injection of the XService
+ * Function that receives DiscordService and config and returns a Trigger
+ * This allows for dependency injection of the DiscordService
  */
 export type DiscordTriggerFactory = (
+  /**
+   * The underlying Discord service
+   */
   service: DiscordService,
-  runtime: Runtime,
+  /**
+   * Function that returns the plugins runtime
+   */
+  getRuntime: () => Runtime,
   config?: {
     commandPrefix: string;
   }

--- a/packages/plugin-x/src/executors.ts
+++ b/packages/plugin-x/src/executors.ts
@@ -5,19 +5,10 @@ import { generateTweetTemplate } from "./templates";
 import { PostTweetSchema, TweetOptions, XExecutorFactory } from "./types";
 
 /**
- * Creates an executor with a bound XService and Runtime instance
- * @param factory Factory function that takes XService and Runtime and returns an executor implementation
- * @returns A function that will receive the XService and Runtime instances from the plugin
- */
-export function createXExecutor(factory: XExecutorFactory): XExecutorFactory {
-  return factory;
-}
-
-/**
  * Helper to create a simple executor with name, description, and execute function
  * The execute function will receive context, xService, and runtime
  */
-export function createSimpleXExecutor(
+export function xExecutorFactory(
   name: string,
   description: string,
   execute: (
@@ -26,10 +17,13 @@ export function createSimpleXExecutor(
     runtime: Runtime
   ) => Promise<PluginResult>
 ): XExecutorFactory {
-  return (service: XService, runtime: Runtime): Executor => ({
+  return (service: XService, getRuntime: () => Runtime): Executor => ({
     name,
     description,
-    fn: (context: AgentContext) => execute(context, service, runtime)
+    fn: (context: AgentContext) => {
+      const runtime = getRuntime();
+      return execute(context, service, runtime);
+    }
   });
 }
 
@@ -37,64 +31,48 @@ export function createSimpleXExecutor(
  * Default executor for creating a new post on X (Twitter)
  * This executor extracts text from the user input and creates a new post
  */
-export const createPostExecutor = createXExecutor(
-  (xService: XService, runtime: Runtime): Executor => {
-    return {
-      name: "post_tweet",
-      description: "Post a tweet on X (Twitter)",
-      fn: async (context: AgentContext): Promise<PluginResult> => {
-        try {
-          const tweetTemplate = generateTweetTemplate(context.contextChain);
-          const params = await runtime.operations.getObject(
-            PostTweetSchema,
-            tweetTemplate
-          );
+export const createPostExecutor = xExecutorFactory(
+  "post_tweet",
+  "Post a tweet on X (Twitter)",
+  async (
+    context: AgentContext,
+    xService: XService,
+    runtime: Runtime
+  ): Promise<PluginResult> => {
+    try {
+      const tweetTemplate = generateTweetTemplate(context.contextChain);
+      const params = await runtime.operations.getObject(
+        PostTweetSchema,
+        tweetTemplate
+      );
+      const message = params.tweetText;
+      // Post the tweet
+      const options: TweetOptions = {
+        text: message
+      };
 
-          const message = params.tweetText;
-          // Post the tweet
-          const options: TweetOptions = {
-            text: message
-          };
+      const result = await xService.postTweet(options);
 
-          const result = await xService.postTweet(options);
-
-          if (!result) {
-            return {
-              success: false,
-              error: "Failed to post tweet"
-            };
-          }
-
-          return {
-            success: true,
-            data: {
-              tweet_id: result.id,
-              tweet_url: `https://x.com/i/status/${result.id}`,
-              text: result.text
-            }
-          };
-        } catch (error) {
-          return {
-            success: false,
-            error: String(error)
-          };
-        }
+      if (!result) {
+        return {
+          success: false,
+          error: "Failed to post tweet"
+        };
       }
-    };
+
+      return {
+        success: true,
+        data: {
+          tweet_id: result.id,
+          tweet_url: `https://x.com/i/status/${result.id}`,
+          text: result.text
+        }
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: String(error)
+      };
+    }
   }
 );
-
-/**
- * Default set of executors for the X plugin
- */
-export const DEFAULT_X_EXECUTORS: XExecutorFactory[] = [createPostExecutor];
-
-/**
- * Creates all custom executors with the service bound to them
- */
-export function createAllCustomExecutors(
-  xService: XService,
-  runtime: Runtime
-): Executor[] {
-  return DEFAULT_X_EXECUTORS.map((factory) => factory(xService, runtime));
-}

--- a/packages/plugin-x/src/triggers.ts
+++ b/packages/plugin-x/src/triggers.ts
@@ -28,7 +28,11 @@ export function createXTrigger(factory: XTriggerFactory): XTriggerFactory {
  * This trigger creates a new context chain with instructions for the agent to create a post
  */
 export const periodicPostTrigger = createXTrigger(
-  (xService: XService, runtime: Runtime, config?: TriggerConfig): Trigger => {
+  (
+    xService: XService,
+    getRuntime: () => Runtime,
+    config?: TriggerConfig
+  ): Trigger => {
     // Hardcoded values for posting every 6 hours with 3 hours of randomization
     const baseIntervalMinutes = 360; // 6 hours
     const randomizationMinutes = 180; // 3 hours
@@ -51,6 +55,7 @@ export const periodicPostTrigger = createXTrigger(
 
         const scheduleNextPost = async () => {
           try {
+            const runtime = getRuntime();
             // Calculate random interval
             const randomIntervalMinutes =
               baseIntervalMinutes + Math.random() * randomizationMinutes;
@@ -151,25 +156,3 @@ export const periodicPostTrigger = createXTrigger(
     };
   }
 );
-
-/**
- * Default set of triggers for the X plugin
- */
-export const DEFAULT_X_TRIGGERS: XTriggerFactory[] = [periodicPostTrigger];
-
-/**
- * Creates all custom triggers with the service bound to them
- */
-export function createAllCustomTriggers(
-  xService: XService,
-  runtime: Runtime,
-  config?: TriggerConfig
-): Trigger[] {
-  logger.info("creating all custom triggers", {
-    type: "plugin-x.triggers.creating",
-    config: JSON.stringify(config || {})
-  });
-  return DEFAULT_X_TRIGGERS.map((factory) =>
-    factory(xService, runtime, config)
-  );
-}

--- a/packages/plugin-x/src/types.ts
+++ b/packages/plugin-x/src/types.ts
@@ -22,8 +22,8 @@ export interface XPluginConfig {
 
   // Custom executors and triggers
   // Can be either plain implementations or factory functions that will receive XService
-  customExecutors?: (Executor | XExecutorFactory)[];
-  customTriggers?: (Trigger | XTriggerFactory)[];
+  executorFactories?: XExecutorFactory[];
+  triggerFactories?: XTriggerFactory[];
 }
 
 /**
@@ -45,7 +45,7 @@ export interface TriggerConfig {
  */
 export type XExecutorFactory = (
   service: XService,
-  runtime: Runtime
+  getRuntime: () => Runtime
 ) => Executor;
 
 /**
@@ -54,7 +54,7 @@ export type XExecutorFactory = (
  */
 export type XTriggerFactory = (
   service: XService,
-  runtime: Runtime,
+  getRuntime: () => Runtime,
   config?: TriggerConfig
 ) => Trigger;
 


### PR DESCRIPTION
## Description
Deferred Runtime Access in Plugin Executors and Triggers

### Problem
During plugin initialization, executors and triggers are created before the runtime reference is set on the plugin. This causes runtime-dependent operations to fail when executors or triggers are invoked.

### Solution
Instead of passing the runtime object directly to executor and trigger factories, we now pass a runtime getter function (`() => this.runtime`). This ensures that:

1. Executors and triggers retrieve the runtime instance at execution time, not at creation time
2. The runtime is always available when needed, regardless of initialization order
3. Third-party plugins can safely access runtime operations like `runtime.operations.getObject`

### Changes
- Updated `DiscordExecutorFactory` and `DiscordTriggerFactory` to accept a getter function
- Updated `XExecutorFactory` and `XTriggerFactory` to follow the same pattern
- Simplified executor and trigger registration in the X plugin to match Discord's cleaner approach
- Ensured consistent naming conventions across both plugins

This change preserves the existing plugin lifecycle while ensuring runtime operations are available when needed.

## Related Issues
NA

## Changes Made

- [x] Feature added
- [x] Bug fixed
- [x] Code refactored
- [x] Documentation updated

## How to Test
Run Discord Plugin and X Plugin

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
