### PR TITLE
fix(core): 🐛 release ports on rebuild by fully terminating prior process group

### DIFF
--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -476,6 +476,15 @@ export class Runtime {
       process.exit(0);
     });
 
+    process.on("SIGTERM", async () => {
+      console.log();
+      runtime.logger.info("runtime received SIGTERM signal", {
+        type: "runtime.sigterm"
+      });
+      await runtime.stop();
+      process.exit(0);
+    });
+
     return runtime;
   }
 


### PR DESCRIPTION
## Description

- handle `SIGTERM` in the runtime instance so it gracefully shuts down
- updates `restart.js` to ensure full cleanup of previous processes before starting a new one. It uses `detached: true` to spawn the a new child process in its own process group and terminates it using `process.kill(-pid)`, which kills the entire group, including any subprocesses. This prevents orphaned processes from holding onto ports when rebuilding maiar-starter with new dependencies and is idempotent.

## Related Issues

🐛 ports from previous child process weren't being released due to incomplete termination of subprocesses

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Shell 1:
```sh
# From root dir
pnpm dev
```

Shell 2:
```sh
# From root dir
cd maiar-starter
pnpm dev
```

Change anything in packages/*

Observe that it rebuilds `maiar-starter` and runs it without any error since it terminates the previous process group cleanly, releasing any ports in use, and then starts the newly built version of `maiar-starter` without conflict.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
