### PR TITLE
chore(config): 🔧 define explicit inputs for build, typecheck, and lint targets to improve task caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,73 +3,61 @@
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": [
+        "{projectRoot}/src/**",
+        "{workspaceRoot}/tsup.config.base.ts",
+        "{projectRoot}/package.json",
+        "{projectRoot}/tsup.config.ts",
+        "{projectRoot}/index.html",
+        "{projectRoot}/tsconfig.*.json",
+        "{projectRoot}/vite.config.ts",
+        "{projectRoot}/character.xml",
+        "{projectRoot}/docs/**",
+        "{projectRoot}/static/**",
+        "{projectRoot}/*.ts"
+      ],
       "outputs": ["{projectRoot}/dist/**", "{projectRoot}/build/**"],
       "cache": true
     },
     "typecheck": {
+      "inputs": [
+        "{workspaceRoot}/tsconfig.base.json",
+        "{projectRoot}/tsconfig.json"
+      ],
       "cache": true
     },
-    "lint": {
-      "cache": true
-    }
+    "lint": { "inputs": ["{workspaceRoot}/eslint.config.js"], "cache": true }
   },
   "parallel": 20,
   "plugins": [
     {
       "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "eslint:lint"
-      }
+      "options": { "targetName": "eslint:lint" }
     },
-    {
-      "plugin": "@nx/js/typescript"
-    }
+    { "plugin": "@nx/js/typescript" }
   ],
   "release": {
     "projects": ["packages/*"],
     "conventionalCommits": {
       "types": {
-        "docs": {
-          "semverBump": "none"
-        },
-        "style": {
-          "semverBump": "none"
-        },
-        "refactor": {
-          "semverBump": "none"
-        },
-        "perf": {
-          "semverBump": "none"
-        },
-        "test": {
-          "semverBump": "none"
-        },
-        "build": {
-          "semverBump": "none"
-        },
-        "ci": {
-          "semverBump": "none"
-        },
+        "docs": { "semverBump": "none" },
+        "style": { "semverBump": "none" },
+        "refactor": { "semverBump": "none" },
+        "perf": { "semverBump": "none" },
+        "test": { "semverBump": "none" },
+        "build": { "semverBump": "none" },
+        "ci": { "semverBump": "none" },
         "cd": {
           "semverBump": "none",
-          "changelog": {
-            "title": "🚚 CD",
-            "hidden": false
-          }
+          "changelog": { "title": "🚚 CD", "hidden": false }
         },
-        "chore": {
-          "semverBump": "none"
-        },
-        "revert": {
-          "semverBump": "none"
-        }
+        "chore": { "semverBump": "none" },
+        "revert": { "semverBump": "none" }
       }
     },
     "version": {
       "conventionalCommits": true,
-      "generatorOptions": {
-        "preserveLocalDependencyProtocols": true
-      }
+      "generatorOptions": { "preserveLocalDependencyProtocols": true }
     },
     "changelog": {
       "workspaceChangelog": {


### PR DESCRIPTION
## Description

- Replaces default with a precise list of inputs relevant to the actual build process, including:
   - src/** and top-level ts files
   - project-specific config files (tsup, vite, tsconfig)
   - html and static assets
   - docs and metadata files like character.xml
- This change improves cache hit rate while ensuring proper invalidation when relevant inputs change. aAso added minimal input sets for typecheck and lint to keep them efficient and accurate.
- Should reduce CI times and local rebuild noise.
- Docs: https://nx.dev/recipes/running-tasks/configure-inputs

## Related Issues

- Previously, the Nx build target used the generic `default` input set, which included all files in the project directory. This was overly broad and could cause unnecessary rebuilds when unrelated files changed.


## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

1. **Clean the cache**:  
   run `nx reset` to ensure no stale artifacts affect results.

2. **Trigger each target**:  
   run `npx nx build <project>`, `npx nx typecheck <project>`, and `npx nx lint <project>` to confirm they execute normally.

3. **Verify caching**:  
   run the same commands again — they should be instant and show "Cached" in the output.

4. **Touch input files**:  
   make small edits to any of the defined inputs (e.g., `src/index.ts`, `tsup.config.ts`) and rerun the targets. they should re-run, NOT be cached.

5. **Touch non-input files**:  
   change a file not listed in inputs (e.g., README.md) and rerun the targets — they should still be cached.

This confirms inputs are correctly scoped and task caching is behaving as expected.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
