### PR TITLE
ci(cd): 👷 add pre-release workflow and automatic tag-based publishing

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,55 @@
+---
+name: 🏷️ Github Pre-release
+run-name: 🏷️ Github Pre-release - Tag & Publish Pre-release from ${{ github.ref_name }} by @${{ github.actor }}
+on:
+  workflow_dispatch:
+    inputs:
+      pre-id:
+        description: "Pre-release identifier (e.g., alpha, beta, rc)"
+        required: true
+        type: choice
+        options:
+          - alpha
+          - beta
+          - rc
+
+env:
+  CI: ${{ vars.CI }}
+  HUSKY: ${{ vars.HUSKY }}
+
+jobs:
+  github-release:
+    name: 🏷️ Github Pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔑 Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: 🛒 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: 🔧 Configure Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - uses: ./.github/actions/setup
+
+      - name: 🔖 Github Release (Tag + Release)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm nx:release version prerelease --preid ${{ github.event.inputs.pre-id }}
+
+          # Use this locally when you've manually bumped a prerelease (e.g. 0.0.1-alpha.0 → 0.1.0-alpha.0, patch prerelease → minor prerelease)
+          # Generates changelog from last *stable* tag up to current prerelease version
+          VERSION=$(jq -r '.version' packages/core/package.json)
+          LATEST_STABLE=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+          pnpm nx:release changelog $VERSION --from $LATEST_STABLE

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -13,6 +13,10 @@ on:
           - beta
           - rc
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: ${{ vars.CI }}
   HUSKY: ${{ vars.HUSKY }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,10 @@ run-name: 🚀 Publish NPM Package - Using Latest Git Tag from ${{ github.ref_na
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: ${{ vars.CI }}
   HUSKY: ${{ vars.HUSKY }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,21 @@ name: 🚀 Publish NPM Package
 run-name: 🚀 Publish NPM Package - Using Latest Git Tag from ${{ github.ref_name }} by @${{ github.actor }}
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "The distribution tag to apply to the published package (e.g., latest, next)"
+        required: true
+        type: choice
+        options:
+          - latest
+          - next
+
+  push:
+    tags:
+      - "v*.*.*" # stable
+      - "v*.*.*-alpha.*" # alpha prerelease
+      - "v*.*.*-beta.*" # beta prerelease
+      - "v*.*.*-rc.*" # rc prerelease
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +48,21 @@ jobs:
       - name: 🚀 Publish NPM Package
         run: |
           # pnpm publish output errors are not always JSON - Patches Nx v20.8.0 release error handler to log the error - Remove if fixed in Nx on an upgrade
+          # Patch for Nx error output
           sed -i '291s/.*/console.log(err); const stdoutData = JSON.parse(err.stdout?.toString() || "{}");/' node_modules/@nx/js/src/executors/release-publish/release-publish.impl.js
-          pnpm nx:publish
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG_NAME="${{ github.ref_name }}"
+            if [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              TAG="latest"
+            else
+              TAG="next"
+            fi
+          fi
+
+          echo "Publishing with tag: $TAG"
+          pnpm nx:publish --tag $TAG
         env:
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,10 @@ on:
           - "minor"
           - "major"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: ${{ vars.CI }}
   HUSKY: ${{ vars.HUSKY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm nx:release version ${{ github.event.inputs.specifier }}
+
+          # Generates changelog from last *stable* tag up to current prerelease version
           VERSION=$(jq -r '.version' packages/core/package.json)
           LATEST_STABLE=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
           pnpm nx:release changelog $VERSION --from $LATEST_STABLE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,15 @@ name: 🏷️ Github Release
 run-name: 🏷️ Github Release - Tag & Publish Latest Release from ${{ github.ref_name }} by @${{ github.actor }}
 on:
   workflow_dispatch:
+    inputs:
+      specifier:
+        description: "Version specifier (e.g., patch, minor, major)"
+        required: true
+        type: choice
+        options:
+          - "patch"
+          - "minor"
+          - "major"
 
 env:
   CI: ${{ vars.CI }}
@@ -37,4 +46,8 @@ jobs:
       - name: 🔖 Github Release (Tag + Release)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm nx:release
+        run: |
+          pnpm nx:release version ${{ github.event.inputs.specifier }}
+          VERSION=$(jq -r '.version' packages/core/package.json)
+          LATEST_STABLE=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+          pnpm nx:release changelog $VERSION --from $LATEST_STABLE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Maiar banner](./website/static/img/maiar-banner.png)
+![Maiar banner](./apps/website/static/img/maiar-banner.png)
 
 # MAIAR: A Composable, Plugin-Based AI Agent Framework
 

--- a/nx.json
+++ b/nx.json
@@ -69,13 +69,13 @@
           "commitReferences": true,
           "versionTitleDate": true
         }
+      },
+      "git": {
+        "commit": true,
+        "commitMessage": "chore(release): 🔖 create new tag/release v{version}",
+        "tag": true,
+        "push": true
       }
-    },
-    "git": {
-      "commit": true,
-      "commitMessage": "chore(release): 🔖 create new tag/release v{version}",
-      "tag": true,
-      "push": true
     }
   },
   "nxCloudId": "680680b4fd4eb5799867a98a"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nx:login": "nx login",
     "nx:reset": "nx reset",
     "nx:graph": "nx graph",
-    "nx:release": "nx release --skip-publish --verbose",
+    "nx:release": "nx release --verbose",
     "nx:publish": "nx release publish --verbose"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Implements a pre-release GHA workflow and standardizes related release infra. Notable changes:

- Adds dedicated pre-release GHA workflow  
- Infers NPM tag from Git tag or workflow input (pre-release, release, publish)  
- Cancels in-progress workflows on same branch for release-related jobs  
- Switches to Nx release subcommands for GitHub release + tagging  
- Refactors Nx config (`release.git` → `release.changelog.git`)  
- Removes unused `--skip-publish` from `nx:release`  npm script
- Minor docs updates + comments for release setup  

This enables smoother prerelease publishing and cleaner job isolation across release flows.

## Related Issues

- No dedicated infrastructure for pre-releases. existing release workflows were tightly coupled to stable releases, making it hard to test or publish prerelease versions in isolation.
- Lacked npm tag inference, branch safety, and modular release flows.

## Changes Made

- [x] Feature added
- [x] Bug fixed
- [x] Code refactored
- [x] Documentation updated

## How to Test

🔹 *Pre-release Workflow (🏷️ Github Pre-release)*

Can be manually triggered via `workflow_dispatch`:

1. Go to **Actions** → **🏷️ Github Pre-release**
2. Click **"Run workflow"**
3. Choose a `pre-id`: `alpha`, `beta`, or `rc`
4. Run the workflow

This:
- Bumps prerelease version using `pnpm nx:release version prerelease --preid <pre-id>`
- Generates changelog from last *stable* version up to current version
- Tags the commit and creates a GitHub pre-release

Once complete, this triggers the **🚀 Publish NPM Package** workflow via the new git tag.

🔹 *Release Workflow*

When pushing a stable git tag (e.g. `v1.2.3`), the existing release workflow handles changelog + tagging via `nx release`.  
It then also triggers the **🚀 Publish NPM Package** workflow automatically on tag push.

Tested in Local Private NPM Registry using Dockerized Verdaccio
<img width="1639" alt="Screenshot 2025-04-22 at 12 13 54 AM" src="https://github.com/user-attachments/assets/df66ef34-1a42-4088-ae95-479aadee427d" />


## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
