### PR TITLE
fix(client): default chat url

### DIFF
--- a/apps/client/src/config.ts
+++ b/apps/client/src/config.ts
@@ -14,7 +14,7 @@ export const DEFAULT_URLS = {
   /**
    * Default HTTP URL for chat API
    */
-  CHAT_API: "http://localhost:3000/message"
+  CHAT_API: "http://localhost:3000/chat"
 };
 
 /**


### PR DESCRIPTION
## Description

Update the clients default chat URL from `http://localhost:3000/messages` to `http://localhost:3000/chat` as in [TextPlugin](https://github.com/UraniumCorporation/maiar-ai/blob/main/packages/plugin-text/src/plugin.ts#L50)

## Related Issues

<!-- Link related issues if applicable, e.g., "Closes #123" -->

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

<!-- Steps to verify your changes. Include commands, expected behavior, etc. -->

## Checklist

- [ ] Code follows project style guidelines
- [ ] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [x] Ready for review 🚀
