### PR TITLE
refactor(plugin-mcp): 🔊 improve logging and error handling for client lifecycle

### DIFF
--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -225,9 +225,9 @@ export class MCPPlugin extends Plugin {
  * Supports: type: object / string / number / boolean / integer / array
  * Nested objects & arrays are handled recursively. Anything unknown → z.any().
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 function jsonSchemaToZod(schema: unknown): ZodType<unknown> {
   if (!schema || typeof schema !== "object") return z.any();
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   const s: any = schema;
 
   switch (s.type) {

--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -144,9 +144,22 @@ export class MCPPlugin extends Plugin {
       }
     }
 
-    for (const t of this.transports) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (t as any)?.close?.();
+    for (const transport of this.transports) {
+      try {
+        this.logger.info("closing MCP transport...", {
+          type: "plugin-mcp.shutdown"
+        });
+        await transport.close();
+        this.logger.info("closed MCP transport successfully", {
+          type: "plugin-mcp.shutdown"
+        });
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        this.logger.error("failed to close MCP transport", {
+          type: "plugin-mcp.shutdown",
+          error: error.message
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Description

- Adds structured logging and error handling around MCP client lifecycle—specifically during connect and shutdown phases.

## Related Issues

- Previously, transport shutdown was silent and error-prone due to loose type assertions and no diagnostics. This improves observability and safety.

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

```
# From root dir
pnpm build
cd apps/starter
pnpm start
```

Observe useful plugin-mcp logs
```log
...
$MAIAR | 2025-04-25T05:47:48.242Z | INFO | plugin.plugin-mcp | connecting to MCP server... | type=plugin-mcp.init clientName=puppeteer
$MAIAR | 2025-04-25T05:48:12.760Z | INFO | plugin.plugin-mcp | connected to MCP server successfully | type=plugin-mcp.init clientName=puppeteer tools=["puppeteer_navigate","puppeteer_screenshot","puppeteer_click","puppeteer_fill","puppeteer_select","puppeteer_hover","puppeteer_evaluate"]
$MAIAR | 2025-04-25T05:48:12.761Z | INFO | plugin.plugin-mcp | connecting to MCP server... | type=plugin-mcp.init clientName=everything
$MAIAR | 2025-04-25T05:48:36.693Z | INFO | plugin.plugin-mcp | connected to MCP server successfully | type=plugin-mcp.init clientName=everything tools=["echo","add","printEnv","longRunningOperation","sampleLLM","getTinyImage","annotatedMessage","getResourceReference"]
$MAIAR | 2025-04-25T05:48:36.693Z | INFO | plugin.registry | plugin initialization for "plugin-mcp" successful | type=plugin.init.success plugin=plugin-mcp
$MAIAR | 2025-04-25T05:48:36.694Z | INFO | plugin.registry | plugin "plugin-mcp" registered successfully | type=registry.plugin.registered plugin=plugin-mcp triggers=[] executors=["puppeteer_puppeteer_navigate","puppeteer_puppeteer_screenshot","puppeteer_puppeteer_click","puppeteer_puppeteer_fill","puppeteer_puppeteer_select","puppeteer_puppeteer_hover","puppeteer_puppeteer_evaluate","everything_echo","everything_add","everything_printEnv","everything_longRunningOperation","everything_sampleLLM","everything_getTinyImage","everything_annotatedMessage","everything_getResourceReference"]
...
$MAIAR | 2025-04-25T05:48:54.579Z | INFO | plugin.plugin-mcp | closing MCP client... | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.579Z | INFO | plugin.plugin-mcp | closed MCP client sucessfully | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.580Z | INFO | plugin.plugin-mcp | closing MCP client... | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.580Z | INFO | plugin.plugin-mcp | closed MCP client sucessfully | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.580Z | INFO | plugin.plugin-mcp | closing MCP transport... | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.580Z | INFO | plugin.plugin-mcp | closed MCP transport successfully | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.580Z | INFO | plugin.plugin-mcp | closing MCP transport... | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.580Z | INFO | plugin.plugin-mcp | closed MCP transport successfully | type=plugin-mcp.shutdown
$MAIAR | 2025-04-25T05:48:54.581Z | INFO | plugin.registry | plugin shutdown for "plugin-mcp" successful | type=plugin.shutdown.success plugin=plugin-mcp
$MAIAR | 2025-04-25T05:48:54.581Z | INFO | plugin.registry | plugin "plugin-mcp" unregistered successfully | type=registry.plugin.unregistered plugin=plugin-mcp
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
