### PR TITLE
refactor(plugin-codex): ♻️ invoke codex via npx instead of direct binary call

### DIFF
--- a/packages/plugin-codex/src/plugin.ts
+++ b/packages/plugin-codex/src/plugin.ts
@@ -34,11 +34,11 @@ export class CodexPlugin extends Plugin {
             );
 
             // Resolve the path to the Codex CLI binary
-            const codexCommand = "codex";
+            const command = "npx";
             const pluginRoot = path.join(__dirname, "..");
 
             // Build arguments for the Codex command
-            const args = [];
+            const args = ["codex"];
             if (commandDetails.approvalMode) {
               args.push("-a", commandDetails.approvalMode);
             }
@@ -61,21 +61,16 @@ export class CodexPlugin extends Plugin {
             // Set environment variables, including OPENAI_API_KEY if provided
             const env = {
               ...process.env,
-              OPENAI_API_KEY: config.apiKey,
-              PATH: `${process.env.PATH}:node_modules/.bin`
+              OPENAI_API_KEY: config.apiKey
             };
 
             // Execute the Codex CLI command
-            const { stdout, stderr, exitCode } = await execa(
-              codexCommand,
-              args,
-              {
-                cwd: pluginRoot,
-                env,
-                timeout: config.timeout || 600000, // 600 seconds timeout to prevent hanging
-                maxBuffer: config.maxBuffer || 1024 * 1024 * 10 // 10MB buffer for output
-              }
-            );
+            const { stdout, stderr, exitCode } = await execa(command, args, {
+              cwd: pluginRoot,
+              env,
+              timeout: config.timeout || 600000, // 600 seconds timeout to prevent hanging
+              maxBuffer: config.maxBuffer || 1024 * 1024 * 10 // 10MB buffer for output
+            });
 
             // Return the result
             return {


### PR DESCRIPTION
## Description

Switches from calling the `codex` binary directly to using `npx codex` for improved portability and to ensure local resolution via `node_modules/.bin` - Drops manual `PATH` extension since `npx` handles that internally.

## Related Issues

`plugin-codex` runs the `codex` binary directly, assuming it's accessible via the `PATH`. While this works if the `env` is set up correctly, it's more maintainable to rely on `npx` to resolve it from local `node_modules`

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [X] Code refactored
- [ ] Documentation updated

## How to Test

Run the MAIAR Client in a terminal
```
# From root dir
cd apps/client
pnpm dev
```

In another terminal, run:
```
# From root dir
pnpm build
cd apps/starter
pnpm start
```

In the MAIAR Client prompt chat with the agent to:
`Write me cookie clicker in a single html page using Codex - DO NOT ASK MY QUESTIONS ALONG THE WAY`

Observe that codex still works using `npx`

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
