### PR TITLE
chore(nx,config): 🔧 add custom dev/start scripts and nx start dependency

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,9 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
+    "start": {
+      "dependsOn": ["^build"]
+    },
     "build": {
       "dependsOn": ["^build"],
       "inputs": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
   "scripts": {
     "prepare": "husky",
     "prepublishOnly": "pnpm build",
+    "start": "nx start apps/starter --verbose",
     "dev": "pnpm run build && date +%s > .build-complete && chokidar 'packages/**/*.ts' --ignore 'packages/**/dist/**' -c 'pnpm run build && date +%s > .build-complete'",
+    "dev:client": "cd apps/client && pnpm run dev",
+    "dev:starter": "cd apps/starter && pnpm run dev",
+    "dev:website": "cd apps/website && pnpm run start",
     "build": "nx run-many --target build --projects packages/* --verbose",
     "build:client": "nx build apps/client --verbose",
     "build:starter": "nx build apps/starter --verbose",


### PR DESCRIPTION
## Description

- Adds app-specific `dev` and `start` npm scripts for easier local development. Also updates `nx.json` to ensure start runs only after dependent builds via `targetDefaults`. Improves consistency and avoids runtime issues from missing builds.

## Related Issues

Developer Experience QoL

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Run npm scripts at root dir
- **`start`**  
  runs `nx start apps/starter --verbose` — main entrypoint for starting the `starter` app.

- **`dev:client`**  
  changes into `apps/client` and runs its local dev server via `pnpm run dev`.

- **`dev:starter`**  
  same as above but for `apps/starter`.

- **`dev:website`**  
  enters `apps/website` and runs `pnpm run start` — differs slightly from the others, using a custom `start` process instead of `dev`.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
