### PR TITLE
chore(client): 🔥 remove devDep pkg @types/react-virtualized-auto-sizer@1.0.8

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -31,6 +31,7 @@ const commitlintConfig: UserConfig = {
         "setup", // Project setup
         "config", // Configuration files
         "deps", // Dependency updates
+        "deps-dev", // Development dependency updates
         "feature", // Feature-specific changes
         "bug", // Bug fixes
         "docs", // Documentation

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -27,7 +27,6 @@
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
     "@types/react-grid-layout": "1.3.5",
-    "@types/react-virtualized-auto-sizer": "1.0.8",
     "@types/react-window": "1.8.8",
     "@vitejs/plugin-react": "4.3.4",
     "eslint": "9.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 9.19.0
       '@nx/eslint':
         specifier: 20.8.0
-        version: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(eslint@9.21.0)(nx@20.8.0)
+        version: 20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(eslint@9.21.0(jiti@2.4.2))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/js':
         specifier: 20.8.0
-        version: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(nx@20.8.0)
+        version: 20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@swc-node/register':
         specifier: 1.9.1
-        version: 1.9.1(@swc/core@1.5.7)(@swc/types@0.1.21)(typescript@5.7.3)
+        version: 1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3)
       '@swc/core':
         specifier: 1.5.7
         version: 1.5.7(@swc/helpers@0.5.11)
@@ -55,25 +55,25 @@ importers:
         version: 3.3.0(@types/node@22.13.1)(typescript@5.7.3)
       eslint-config-prettier:
         specifier: 10.0.1
-        version: 10.0.1(eslint@9.21.0)
+        version: 10.0.1(eslint@9.21.0(jiti@2.4.2))
       husky:
         specifier: 9.1.7
         version: 9.1.7
       nx:
         specifier: 20.8.0
-        version: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+        version: 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       prettier:
         specifier: 3.4.2
         version: 3.4.2
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
       typescript-eslint:
         specifier: 8.22.0
-        version: 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
 
   apps/client:
     dependencies:
@@ -82,19 +82,19 @@ importers:
         version: 11.14.0(@types/react@19.0.10)(react@19.0.0)
       '@emotion/styled':
         specifier: 11.14.0
-        version: 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@fontsource/roboto':
         specifier: 5.1.1
         version: 5.1.1
       '@mui/icons-material':
         specifier: 6.4.6
-        version: 6.4.6(@mui/material@6.4.6)(@types/react@19.0.10)(react@19.0.0)
+        version: 6.4.6(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@mui/lab':
         specifier: 6.0.0-beta.29
-        version: 6.0.0-beta.29(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@mui/material@6.4.6)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
+        version: 6.0.0-beta.29(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/material':
         specifier: 6.4.6
-        version: 6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
+        version: 6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -103,13 +103,13 @@ importers:
         version: 19.0.0(react@19.0.0)
       react-grid-layout:
         specifier: 1.5.0
-        version: 1.5.0(react-dom@19.0.0)(react@19.0.0)
+        version: 1.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-virtualized-auto-sizer:
         specifier: 1.0.26
-        version: 1.0.26(react-dom@19.0.0)(react@19.0.0)
+        version: 1.0.26(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-window:
         specifier: 1.8.11
-        version: 1.8.11(react-dom@19.0.0)(react@19.0.0)
+        version: 1.8.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@eslint/js':
         specifier: 9.21.0
@@ -123,24 +123,21 @@ importers:
       '@types/react-grid-layout':
         specifier: 1.3.5
         version: 1.3.5
-      '@types/react-virtualized-auto-sizer':
-        specifier: 1.0.8
-        version: 1.0.8(react-dom@19.0.0)(react@19.0.0)
       '@types/react-window':
         specifier: 1.8.8
         version: 1.8.8
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@6.2.0)
+        version: 4.3.4(vite@6.2.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1))
       eslint:
         specifier: 9.21.0
-        version: 9.21.0
+        version: 9.21.0(jiti@2.4.2)
       eslint-plugin-react-hooks:
         specifier: 5.1.0
-        version: 5.1.0(eslint@9.21.0)
+        version: 5.1.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-react-refresh:
         specifier: 0.4.19
-        version: 0.4.19(eslint@9.21.0)
+        version: 0.4.19(eslint@9.21.0(jiti@2.4.2))
       globals:
         specifier: 15.15.0
         version: 15.15.0
@@ -149,10 +146,10 @@ importers:
         version: 5.7.3
       typescript-eslint:
         specifier: 8.24.1
-        version: 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+        version: 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       vite:
         specifier: 6.2.0
-        version: 6.2.0(@types/node@22.13.1)
+        version: 6.2.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1)
 
   apps/starter:
     dependencies:
@@ -237,7 +234,7 @@ importers:
         version: 8.0.0
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -246,10 +243,10 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/preset-classic':
         specifier: 3.7.0
-        version: 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+        version: 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
       '@mdx-js/react':
         specifier: 3.1.0
         version: 3.1.0(@types/react@19.0.8)(react@19.0.0)
@@ -267,17 +264,17 @@ importers:
         version: 19.0.0(react@19.0.0)
       react-glitch-effect:
         specifier: 3.1.0
-        version: 3.1.0(react-dom@19.0.0)(react@19.0.0)
+        version: 3.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.7.0
-        version: 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+        version: 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/tsconfig':
         specifier: 3.7.0
         version: 3.7.0
       '@docusaurus/types':
         specifier: 3.7.0
-        version: 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+        version: 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/node':
         specifier: 22.13.1
         version: 22.13.1
@@ -289,13 +286,13 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       docusaurus-plugin-typedoc:
         specifier: 1.2.3
-        version: 1.2.3(typedoc-plugin-markdown@4.4.1)
+        version: 1.2.3(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.7.3)))
       typedoc:
         specifier: 0.27.6
         version: 0.27.6(typescript@5.7.3)
       typedoc-plugin-markdown:
         specifier: 4.4.1
-        version: 4.4.1(typedoc@0.27.6)
+        version: 4.4.1(typedoc@0.27.6(typescript@5.7.3))
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -341,7 +338,7 @@ importers:
         version: 8.18.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -360,7 +357,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -388,7 +385,7 @@ importers:
         version: 8.11.11
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -413,7 +410,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -432,7 +429,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -454,7 +451,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -473,7 +470,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -485,7 +482,7 @@ importers:
         version: link:../core
       '@openai/codex':
         specifier: 0.1.2504211509
-        version: 0.1.2504211509
+        version: 0.1.2504211509(@types/react@19.0.10)(ws@8.18.1)
       execa:
         specifier: 9.3.1
         version: 9.3.1
@@ -495,7 +492,7 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -517,7 +514,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -539,7 +536,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -561,7 +558,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -583,7 +580,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -605,7 +602,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -627,7 +624,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -652,7 +649,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -668,7 +665,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -690,7 +687,7 @@ importers:
         version: 8.5.14
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -715,7 +712,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -3242,10 +3239,6 @@ packages:
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
       '@types/react': '*'
-
-  '@types/react-virtualized-auto-sizer@1.0.8':
-    resolution: {integrity: sha512-keJpNyhiwfl2+N12G1ocCVA5ZDBArbPLe/S90X3kt7fam9naeHdaYYWbpe2sHczp70JWJ+2QLhBE8kLvLuVNjA==}
-    deprecated: This is a stub types definition. react-virtualized-auto-sizer provides its own type definitions, so you do not need this installed.
 
   '@types/react-window@1.8.8':
     resolution: {integrity: sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==}
@@ -9696,7 +9689,7 @@ snapshots:
       '@commitlint/types': 19.8.0
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.7.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0)(typescript@5.7.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -9752,22 +9745,22 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.4.1
 
-  '@csstools/cascade-layer-name-parser@2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/cascade-layer-name-parser@2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/color-helpers@5.0.2': {}
 
-  '@csstools/css-calc@2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/css-calc@2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
-  '@csstools/css-color-parser@3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/css-color-parser@3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/color-helpers': 5.0.2
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
@@ -9777,7 +9770,7 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.3': {}
 
-  '@csstools/media-query-list-parser@4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/media-query-list-parser@4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
@@ -9790,7 +9783,7 @@ snapshots:
 
   '@csstools/postcss-color-function@4.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -9799,7 +9792,7 @@ snapshots:
 
   '@csstools/postcss-color-mix-function@3.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -9816,7 +9809,7 @@ snapshots:
 
   '@csstools/postcss-exponential-functions@2.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -9829,14 +9822,14 @@ snapshots:
 
   '@csstools/postcss-gamut-mapping@2.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
   '@csstools/postcss-gradients-interpolation-method@5.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -9845,7 +9838,7 @@ snapshots:
 
   '@csstools/postcss-hwb-function@4.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -9902,17 +9895,17 @@ snapshots:
 
   '@csstools/postcss-media-minmax@2.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
   '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.5.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
   '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.3)':
@@ -9928,7 +9921,7 @@ snapshots:
 
   '@csstools/postcss-oklab-function@4.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -9942,14 +9935,14 @@ snapshots:
 
   '@csstools/postcss-random-function@1.0.3(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
   '@csstools/postcss-relative-color-syntax@3.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -9963,14 +9956,14 @@ snapshots:
 
   '@csstools/postcss-sign-functions@1.1.2(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
   '@csstools/postcss-stepped-value-functions@4.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -9983,7 +9976,7 @@ snapshots:
 
   '@csstools/postcss-trigonometric-functions@4.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -10061,20 +10054,21 @@ snapshots:
 
   '@docsearch/css@3.9.0': {}
 
-  '@docsearch/react@3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)':
+  '@docsearch/react@3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.23.4)(algoliasearch@5.23.4)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.23.4)(algoliasearch@5.23.4)
       '@docsearch/css': 3.9.0
-      '@types/react': 19.0.8
       algoliasearch: 5.23.4
+    optionalDependencies:
+      '@types/react': 19.0.8
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/babel@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/generator': 7.27.0
@@ -10087,7 +10081,7 @@ snapshots:
       '@babel/runtime-corejs3': 7.27.0
       '@babel/traverse': 7.27.0
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.0
       tslib: 2.8.1
@@ -10101,33 +10095,33 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/bundler@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.26.10
-      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/cssnano-preset': 3.7.0
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.99.6)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.99.6)
-      css-loader: 6.11.0(webpack@5.99.6)
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6)
+      copy-webpack-plugin: 11.0.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      css-loader: 6.11.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       cssnano: 6.1.2(postcss@8.5.3)
-      file-loader: 6.2.0(webpack@5.99.6)
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.9.2(webpack@5.99.6)
-      null-loader: 4.0.1(webpack@5.99.6)
+      mini-css-extract-plugin: 2.9.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      null-loader: 4.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       postcss: 8.5.3
-      postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6)
+      postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       postcss-preset-env: 10.1.5(postcss@8.5.3)
-      react-dev-utils: 12.0.1(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6)
-      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.99.6)
+      react-dev-utils: 12.0.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.99.6)
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
-      webpackbar: 6.0.1(webpack@5.99.6)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+      webpackbar: 6.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10146,15 +10140,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/bundler': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/bundler': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mdx-js/react': 3.1.0(@types/react@19.0.8)(react@19.0.0)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10170,28 +10164,28 @@ snapshots:
       eval: 0.1.8
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(webpack@5.99.6)
+      html-webpack-plugin: 5.6.3(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       leven: 3.1.0
       lodash: 4.17.21
       p-map: 4.0.0
       prompts: 2.4.2
       react: 19.0.0
-      react-dev-utils: 12.0.1(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6)
+      react-dev-utils: 12.0.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       react-dom: 19.0.0(react@19.0.0)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)'
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.0.0)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.99.6)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       react-router: 5.3.4(react@19.0.0)
-      react-router-config: 5.1.1(react-router@5.3.4)(react@19.0.0)
+      react-router-config: 5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0)
       react-router-dom: 5.3.4(react@19.0.0)
       semver: 7.7.1
       serve-handler: 6.1.6
       shelljs: 0.8.5
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(webpack@5.99.6)
+      webpack-dev-server: 4.15.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -10225,16 +10219,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/mdx-loader@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.3.3
-      file-loader: 6.2.0(webpack@5.99.6)
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       fs-extra: 11.3.0
       image-size: 1.2.1
       mdast-util-mdx: 3.0.0
@@ -10250,9 +10244,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.99.6)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       vfile: 6.0.3
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@swc/core'
       - acorn
@@ -10261,16 +10255,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/module-type-aliases@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/history': 4.7.11
       '@types/react': 19.0.10
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)'
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.0.0)'
     transitivePeerDependencies:
       - '@swc/core'
@@ -10280,17 +10274,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.0
@@ -10302,7 +10296,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10324,17 +10318,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.0
@@ -10344,7 +10338,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10366,18 +10360,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10399,11 +10393,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -10430,11 +10424,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -10459,11 +10453,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/gtag.js': 0.0.12
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -10489,11 +10483,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -10518,14 +10512,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -10552,18 +10546,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/webpack': 8.1.0(typescript@5.7.3)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -10585,22 +10579,22 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
+  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-classic': 3.7.0(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-classic': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
@@ -10632,21 +10626,21 @@ snapshots:
       '@types/react': 19.0.10
       react: 19.0.0
 
-  '@docusaurus/theme-classic@3.7.0(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/theme-classic@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/theme-translations': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mdx-js/react': 3.1.0(@types/react@19.0.8)(react@19.0.0)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -10683,13 +10677,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/history': 4.7.11
       '@types/react': 19.0.10
       '@types/react-router-config': 5.0.11
@@ -10708,16 +10702,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
+  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
     dependencies:
-      '@docsearch/react': 3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docsearch/react': 3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/theme-translations': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       algoliasearch: 5.23.4
       algoliasearch-helper: 3.24.3(algoliasearch@5.23.4)
       clsx: 2.1.1
@@ -10759,7 +10753,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.7.0': {}
 
-  '@docusaurus/types@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/types@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@types/history': 4.7.11
@@ -10768,9 +10762,9 @@ snapshots:
       joi: 17.13.3
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)'
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)'
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -10780,9 +10774,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/utils-common@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -10794,11 +10788,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/utils-validation@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -10814,13 +10808,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/utils@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.99.6)
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       fs-extra: 11.3.0
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -10833,9 +10827,9 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.99.6)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@swc/core'
       - acorn
@@ -10900,9 +10894,10 @@ snapshots:
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
-      '@types/react': 19.0.10
       hoist-non-react-statics: 3.3.2
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
     transitivePeerDependencies:
       - supports-color
 
@@ -10916,7 +10911,7 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/babel-plugin': 11.13.5
@@ -10925,8 +10920,9 @@ snapshots:
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
       '@emotion/utils': 1.4.2
-      '@types/react': 19.0.10
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
     transitivePeerDependencies:
       - supports-color
 
@@ -11090,9 +11086,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.6.1(eslint@9.21.0)':
+  '@eslint-community/eslint-utils@4.6.1(eslint@9.21.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -11147,7 +11143,7 @@ snapshots:
       '@floating-ui/core': 1.6.9
       '@floating-ui/utils': 0.2.9
 
-  '@floating-ui/react-dom@2.1.2(react-dom@19.0.0)(react@19.0.0)':
+  '@floating-ui/react-dom@2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       react: 19.0.0
@@ -11182,13 +11178,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@inkjs/ui@2.0.0(ink@5.2.0)':
+  '@inkjs/ui@2.0.0(ink@5.2.0(@types/react@19.0.10)(react@18.3.1))':
     dependencies:
       chalk: 5.4.1
       cli-spinners: 3.2.0
       deepmerge: 4.3.1
       figures: 6.1.0
-      ink: 5.2.0(react@18.3.1)
+      ink: 5.2.0(@types/react@19.0.10)(react@18.3.1)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -11287,55 +11283,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/base@5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)':
+  '@mui/base@5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0)(react@19.0.0)
+      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/types': 7.4.1(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
       '@popperjs/core': 2.11.8
-      '@types/react': 19.0.10
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
 
   '@mui/core-downloads-tracker@6.4.11': {}
 
-  '@mui/icons-material@6.4.6(@mui/material@6.4.6)(@types/react@19.0.10)(react@19.0.0)':
+  '@mui/icons-material@6.4.6(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@mui/material': 6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
-      '@types/react': 19.0.10
+      '@mui/material': 6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
 
-  '@mui/lab@6.0.0-beta.29(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@mui/material@6.4.6)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)':
+  '@mui/lab@6.0.0-beta.29(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
-      '@mui/base': 5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
-      '@mui/material': 6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
-      '@mui/system': 6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@19.0.0)
+      '@mui/base': 5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mui/material': 6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@mui/types': 7.4.1(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@types/react': 19.0.10
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
+      '@types/react': 19.0.10
 
-  '@mui/material@6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)':
+  '@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
       '@mui/core-downloads-tracker': 6.4.11
-      '@mui/system': 6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@19.0.0)
+      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@mui/types': 7.4.1(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
       '@popperjs/core': 2.11.8
-      '@types/react': 19.0.10
       '@types/react-transition-group': 4.4.12(@types/react@19.0.10)
       clsx: 2.1.1
       csstype: 3.1.3
@@ -11343,50 +11339,58 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-is: 19.1.0
-      react-transition-group: 4.4.5(react-dom@19.0.0)(react@19.0.0)
+      react-transition-group: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
+      '@types/react': 19.0.10
 
   '@mui/private-theming@6.4.9(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@types/react': 19.0.10
       prop-types: 15.8.1
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
 
-  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@19.0.0)':
+  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 19.0.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
 
-  '@mui/system@6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@19.0.0)':
+  '@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
       '@mui/private-theming': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@19.0.0)
+      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(react@19.0.0)
       '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@types/react': 19.0.10
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 19.0.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
+      '@types/react': 19.0.10
 
   '@mui/types@7.2.24(@types/react@19.0.10)':
-    dependencies:
+    optionalDependencies:
       '@types/react': 19.0.10
 
   '@mui/types@7.4.1(@types/react@19.0.10)':
     dependencies:
       '@babel/runtime': 7.27.0
+    optionalDependencies:
       '@types/react': 19.0.10
 
   '@mui/utils@6.4.9(@types/react@19.0.10)(react@19.0.0)':
@@ -11394,11 +11398,12 @@ snapshots:
       '@babel/runtime': 7.27.0
       '@mui/types': 7.2.24(@types/react@19.0.10)
       '@types/prop-types': 15.7.14
-      '@types/react': 19.0.10
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.0.0
       react-is: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.0.10
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -11418,26 +11423,28 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nx/devkit@20.8.0(nx@20.8.0)':
+  '@nx/devkit@20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))':
     dependencies:
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+      nx: 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       semver: 7.7.1
       tmp: 0.2.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(eslint@9.21.0)(nx@20.8.0)':
+  '@nx/eslint@20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(eslint@9.21.0(jiti@2.4.2))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))':
     dependencies:
-      '@nx/devkit': 20.8.0(nx@20.8.0)
-      '@nx/js': 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(nx@20.8.0)
-      eslint: 9.21.0
+      '@nx/devkit': 20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
+      '@nx/js': 20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
+      eslint: 9.21.0(jiti@2.4.2)
       semver: 7.7.1
       tslib: 2.8.1
       typescript: 5.7.3
+    optionalDependencies:
+      '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -11447,7 +11454,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/js@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(nx@20.8.0)':
+  '@nx/js@20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
@@ -11456,12 +11463,12 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
       '@babel/runtime': 7.27.0
-      '@nx/devkit': 20.8.0(nx@20.8.0)
-      '@nx/workspace': 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+      '@nx/devkit': 20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
+      '@nx/workspace': 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       '@zkochan/js-yaml': 0.0.7
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.10)
       babel-plugin-macros: 3.1.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.10)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.10)(@babel/traverse@7.27.0)
       chalk: 4.1.2
       columnify: 1.6.0
       detect-port: 1.6.1
@@ -11516,13 +11523,13 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.8.0':
     optional: true
 
-  '@nx/workspace@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)':
+  '@nx/workspace@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))':
     dependencies:
-      '@nx/devkit': 20.8.0(nx@20.8.0)
+      '@nx/devkit': 20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@zkochan/js-yaml': 0.0.7
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+      nx: 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       picomatch: 4.0.2
       tslib: 2.8.1
       yargs-parser: 21.1.1
@@ -11531,9 +11538,9 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@openai/codex@0.1.2504211509':
+  '@openai/codex@0.1.2504211509(@types/react@19.0.10)(ws@8.18.1)':
     dependencies:
-      '@inkjs/ui': 2.0.0(ink@5.2.0)
+      '@inkjs/ui': 2.0.0(ink@5.2.0(@types/react@19.0.10)(react@18.3.1))
       chalk: 5.4.1
       diff: 7.0.0
       dotenv: 16.4.7
@@ -11541,13 +11548,13 @@ snapshots:
       fast-npm-meta: 0.4.2
       figures: 6.1.0
       file-type: 20.4.1
-      ink: 5.2.0(react@18.3.1)
+      ink: 5.2.0(@types/react@19.0.10)(react@18.3.1)
       js-yaml: 4.1.0
       marked: 15.0.9
       marked-terminal: 7.3.0(marked@15.0.9)
       meow: 13.2.0
       open: 10.1.1
-      openai: 4.95.1(zod@3.24.3)
+      openai: 4.95.1(ws@8.18.1)(zod@3.24.3)
       package-manager-detector: 1.2.0
       react: 18.3.1
       shell-quote: 1.8.2
@@ -11682,7 +11689,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)':
+  '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       invariant: 2.2.4
@@ -11758,7 +11765,7 @@ snapshots:
       '@babel/types': 7.27.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.7.3))':
     dependencies:
       '@babel/core': 7.26.10
       '@svgr/babel-preset': 8.1.0(@babel/core@7.26.10)
@@ -11768,7 +11775,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@5.7.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.7.3)
       cosmiconfig: 8.3.6(typescript@5.7.3)
@@ -11785,20 +11792,20 @@ snapshots:
       '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
       '@svgr/core': 8.1.0(typescript@5.7.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.7.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@swc-node/core@1.13.3(@swc/core@1.5.7)(@swc/types@0.1.21)':
+  '@swc-node/core@1.13.3(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)':
     dependencies:
       '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       '@swc/types': 0.1.21
 
-  '@swc-node/register@1.9.1(@swc/core@1.5.7)(@swc/types@0.1.21)(typescript@5.7.3)':
+  '@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3)':
     dependencies:
-      '@swc-node/core': 1.13.3(@swc/core@1.5.7)(@swc/types@0.1.21)
+      '@swc-node/core': 1.13.3(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       colorette: 2.0.20
@@ -11848,7 +11855,6 @@ snapshots:
   '@swc/core@1.5.7(@swc/helpers@0.5.11)':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.11
       '@swc/types': 0.1.7
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.5.7
@@ -11861,6 +11867,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.5.7
       '@swc/core-win32-ia32-msvc': 1.5.7
       '@swc/core-win32-x64-msvc': 1.5.7
+      '@swc/helpers': 0.5.11
 
   '@swc/counter@0.1.3': {}
 
@@ -12117,13 +12124,6 @@ snapshots:
     dependencies:
       '@types/react': 19.0.10
 
-  '@types/react-virtualized-auto-sizer@1.0.8(react-dom@19.0.0)(react@19.0.0)':
-    dependencies:
-      react-virtualized-auto-sizer: 1.0.26(react-dom@19.0.0)(react@19.0.0)
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
   '@types/react-window@1.8.8':
     dependencies:
       '@types/react': 19.0.10
@@ -12181,15 +12181,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.22.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -12198,15 +12198,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1)(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/type-utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -12215,26 +12215,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.22.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.22.0
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.22.0
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.24.1(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -12249,23 +12249,23 @@ snapshots:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/visitor-keys': 8.24.1
 
-  '@typescript-eslint/type-utils@8.22.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.24.1(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -12303,24 +12303,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.22.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.22.0
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.24.1(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -12337,14 +12337,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.0)':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.0(@types/node@22.13.1)
+      vite: 6.2.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12482,7 +12482,7 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
-    dependencies:
+    optionalDependencies:
       ajv: 8.17.1
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -12620,12 +12620,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.99.6):
+  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.26.10):
     dependencies:
@@ -12670,10 +12670,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.10):
+  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.10)(@babel/traverse@7.27.0):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
+    optionalDependencies:
+      '@babel/traverse': 7.27.0
 
   bail@2.0.2: {}
 
@@ -13182,7 +13184,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.0: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.99.6):
+  copy-webpack-plugin@11.0.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -13190,7 +13192,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   core-js-compat@3.41.0:
     dependencies:
@@ -13207,7 +13209,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0)(typescript@5.7.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
       '@types/node': 22.13.1
       cosmiconfig: 9.0.0(typescript@5.7.3)
@@ -13236,6 +13238,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.7.3
 
   cosmiconfig@9.0.0(typescript@5.7.3):
@@ -13244,6 +13247,7 @@ snapshots:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
       typescript: 5.7.3
 
   cross-spawn@7.0.6:
@@ -13272,7 +13276,7 @@ snapshots:
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.99.6):
+  css-loader@6.11.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -13282,19 +13286,21 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.3)
       postcss-value-parser: 4.2.0
       semver: 7.7.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+    optionalDependencies:
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.5.3)
-      esbuild: 0.24.2
       jest-worker: 29.7.0
       postcss: 8.5.3
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      clean-css: 5.3.3
+      esbuild: 0.24.2
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.3):
     dependencies:
@@ -13551,9 +13557,9 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
-  docusaurus-plugin-typedoc@1.2.3(typedoc-plugin-markdown@4.4.1):
+  docusaurus-plugin-typedoc@1.2.3(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.7.3))):
     dependencies:
-      typedoc-plugin-markdown: 4.4.1(typedoc@0.27.6)
+      typedoc-plugin-markdown: 4.4.1(typedoc@0.27.6(typescript@5.7.3))
 
   dom-converter@0.2.0:
     dependencies:
@@ -13792,17 +13798,17 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.0.1(eslint@9.21.0):
+  eslint-config-prettier@10.0.1(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
 
-  eslint-plugin-react-hooks@5.1.0(eslint@9.21.0):
+  eslint-plugin-react-hooks@5.1.0(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
 
-  eslint-plugin-react-refresh@0.4.19(eslint@9.21.0):
+  eslint-plugin-react-refresh@0.4.19(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -13818,9 +13824,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.21.0:
+  eslint@9.21.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.2
       '@eslint/core': 0.12.0
@@ -13854,6 +13860,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14087,7 +14095,7 @@ snapshots:
       websocket-driver: 0.7.4
 
   fdir@6.4.4(picomatch@4.0.2):
-    dependencies:
+    optionalDependencies:
       picomatch: 4.0.2
 
   fecha@4.2.3: {}
@@ -14115,11 +14123,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.99.6):
+  file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   file-type@20.4.1:
     dependencies:
@@ -14222,7 +14230,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@types/json-schema': 7.0.15
@@ -14230,7 +14238,6 @@ snapshots:
       chokidar: 3.6.0
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 9.21.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.5.3
@@ -14239,7 +14246,9 @@ snapshots:
       semver: 7.7.1
       tapable: 1.1.3
       typescript: 5.7.3
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      eslint: 9.21.0(jiti@2.4.2)
 
   form-data-encoder@1.7.2: {}
 
@@ -14643,14 +14652,15 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.99.6):
+  html-webpack-plugin@5.6.3(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+    optionalDependencies:
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -14689,12 +14699,13 @@ snapshots:
 
   http-proxy-middleware@2.0.9(@types/express@4.17.21):
     dependencies:
-      '@types/express': 4.17.21
       '@types/http-proxy': 1.17.16
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
+    optionalDependencies:
+      '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
 
@@ -14775,7 +14786,7 @@ snapshots:
 
   ini@4.1.1: {}
 
-  ink@5.2.0(react@18.3.1):
+  ink@5.2.0(@types/react@19.0.10)(react@18.3.1):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.1.3
       ansi-escapes: 7.0.0
@@ -14802,6 +14813,8 @@ snapshots:
       wrap-ansi: 9.0.0
       ws: 8.18.1
       yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.0.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -15772,11 +15785,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.99.6):
+  mini-css-extract-plugin@2.9.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   minimalistic-assert@1.0.1: {}
 
@@ -15904,17 +15917,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.99.6):
+  null-loader@4.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
-  nx@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7):
+  nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
-      '@swc-node/register': 1.9.1(@swc/core@1.5.7)(@swc/types@0.1.21)(typescript@5.7.3)
-      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
@@ -15959,6 +15970,8 @@ snapshots:
       '@nx/nx-linux-x64-musl': 20.8.0
       '@nx/nx-win32-arm64-msvc': 20.8.0
       '@nx/nx-win32-x64-msvc': 20.8.0
+      '@swc-node/register': 1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3)
+      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
     transitivePeerDependencies:
       - debug
 
@@ -16019,12 +16032,13 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+    optionalDependencies:
       ws: 8.18.1
       zod: 3.24.1
     transitivePeerDependencies:
       - encoding
 
-  openai@4.95.1(zod@3.24.3):
+  openai@4.95.1(ws@8.18.1)(zod@3.24.3):
     dependencies:
       '@types/node': 18.19.86
       '@types/node-fetch': 2.6.12
@@ -16033,6 +16047,8 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.1
       zod: 3.24.3
     transitivePeerDependencies:
       - encoding
@@ -16308,7 +16324,7 @@ snapshots:
 
   postcss-color-functional-notation@7.0.8(postcss@8.5.3):
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -16343,15 +16359,15 @@ snapshots:
 
   postcss-custom-media@11.0.5(postcss@8.5.3):
     dependencies:
-      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
   postcss-custom-properties@14.0.4(postcss@8.5.3):
     dependencies:
-      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
@@ -16360,7 +16376,7 @@ snapshots:
 
   postcss-custom-selectors@8.0.4(postcss@8.5.3):
     dependencies:
-      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -16425,24 +16441,28 @@ snapshots:
 
   postcss-lab-function@7.0.8(postcss@8.5.3):
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.7.1):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.4.2
+      postcss: 8.5.3
+      yaml: 2.7.1
 
-  postcss-loader@7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6):
+  postcss-loader@7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.7.3)
       jiti: 1.21.7
       postcss: 8.5.3
       semver: 7.7.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - typescript
 
@@ -16879,7 +16899,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6):
+  react-dev-utils@12.0.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/code-frame': 7.26.2
       address: 1.2.2
@@ -16890,7 +16910,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -16905,8 +16925,9 @@ snapshots:
       shell-quote: 1.8.2
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
       typescript: 5.7.3
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -16917,7 +16938,7 @@ snapshots:
       react: 19.0.0
       scheduler: 0.25.0
 
-  react-draggable@4.4.6(react-dom@19.0.0)(react@19.0.0):
+  react-draggable@4.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       clsx: 1.2.1
       prop-types: 15.8.1
@@ -16928,21 +16949,21 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-glitch-effect@3.1.0(react-dom@19.0.0)(react@19.0.0):
+  react-glitch-effect@3.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  react-grid-layout@1.5.0(react-dom@19.0.0)(react@19.0.0):
+  react-grid-layout@1.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       clsx: 2.1.1
       fast-equals: 4.0.3
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-draggable: 4.4.6(react-dom@19.0.0)(react@19.0.0)
-      react-resizable: 3.0.5(react-dom@19.0.0)(react@19.0.0)
+      react-draggable: 4.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-resizable: 3.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       resize-observer-polyfill: 1.5.1
 
   react-is@16.13.1: {}
@@ -16955,11 +16976,11 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.99.6):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/runtime': 7.27.0
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.0.0)'
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   react-reconciler@0.29.2(react@18.3.1):
     dependencies:
@@ -16969,15 +16990,15 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-resizable@3.0.5(react-dom@19.0.0)(react@19.0.0):
+  react-resizable@3.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       prop-types: 15.8.1
       react: 19.0.0
-      react-draggable: 4.4.6(react-dom@19.0.0)(react@19.0.0)
+      react-draggable: 4.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
 
-  react-router-config@5.1.1(react-router@5.3.4)(react@19.0.0):
+  react-router-config@5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.27.0
       react: 19.0.0
@@ -17007,7 +17028,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-transition-group@4.4.5(react-dom@19.0.0)(react@19.0.0):
+  react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.27.0
       dom-helpers: 5.2.1
@@ -17016,12 +17037,12 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  react-virtualized-auto-sizer@1.0.26(react-dom@19.0.0)(react@19.0.0):
+  react-virtualized-auto-sizer@1.0.26(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  react-window@1.8.11(react-dom@19.0.0)(react@19.0.0):
+  react-window@1.8.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.27.0
       memoize-one: 5.2.1
@@ -17832,16 +17853,17 @@ snapshots:
       - encoding
       - supports-color
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.99.6):
+  terser-webpack-plugin@5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
-      esbuild: 0.24.2
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
+      esbuild: 0.24.2
 
   terser@5.39.0:
     dependencies:
@@ -17930,9 +17952,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.6(@swc/core@1.5.7)(typescript@5.7.3):
+  tsup@8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1):
     dependencies:
-      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       bundle-require: 5.1.0(esbuild@0.24.2)
       cac: 6.7.14
       chokidar: 4.0.3
@@ -17941,7 +17962,7 @@ snapshots:
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.7.1)
       resolve-from: 5.0.0
       rollup: 4.40.0
       source-map: 0.8.0-beta.0
@@ -17949,6 +17970,9 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
+      postcss: 8.5.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - jiti
@@ -17987,7 +18011,7 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typedoc-plugin-markdown@4.4.1(typedoc@0.27.6):
+  typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.7.3)):
     dependencies:
       typedoc: 0.27.6(typescript@5.7.3)
 
@@ -18000,22 +18024,22 @@ snapshots:
       typescript: 5.7.3
       yaml: 2.7.1
 
-  typescript-eslint@8.22.0(eslint@9.21.0)(typescript@5.7.3):
+  typescript-eslint@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
-      eslint: 9.21.0
+      '@typescript-eslint/eslint-plugin': 8.22.0(@typescript-eslint/parser@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.24.1(eslint@9.21.0)(typescript@5.7.3):
+  typescript-eslint@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1)(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
-      eslint: 9.21.0
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -18119,13 +18143,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0)(webpack@5.99.6):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
-      file-loader: 6.2.0(webpack@5.99.6)
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
 
   use-interval@1.4.0(react@18.3.1):
     dependencies:
@@ -18162,14 +18187,17 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@6.2.0(@types/node@22.13.1):
+  vite@6.2.0(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1):
     dependencies:
-      '@types/node': 22.13.1
       esbuild: 0.25.2
       postcss: 8.5.3
       rollup: 4.40.0
     optionalDependencies:
+      '@types/node': 22.13.1
       fsevents: 2.3.3
+      jiti: 2.4.2
+      terser: 5.39.0
+      yaml: 2.7.1
 
   watchpack@2.4.2:
     dependencies:
@@ -18212,16 +18240,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@5.3.4(webpack@5.99.6):
+  webpack-dev-middleware@5.3.4(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
-  webpack-dev-server@4.15.2(webpack@5.99.6):
+  webpack-dev-server@4.15.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18251,9 +18279,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
-      webpack-dev-middleware: 5.3.4(webpack@5.99.6)
+      webpack-dev-middleware: 5.3.4(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       ws: 8.18.1
+    optionalDependencies:
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18274,7 +18303,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.99.6(@swc/core@1.5.7)(esbuild@0.24.2):
+  webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -18296,7 +18325,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.99.6)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -18304,7 +18333,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.99.6):
+  webpackbar@6.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -18313,7 +18342,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.9.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:


### PR DESCRIPTION
## Description

- Remove devDep pkg `@types/react-virtualized-auto-sizer@1.0.8` since it is bogus and to get rid of pnpm warning

## Related Issues

- `apps/client` pkg @types/react-virtualized-auto-sizer@1.0.8 is a stub definition

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Run `pnpm i` and you will not get a warning for pkg `@types/react-virtualized-auto-sizer@1.0.8` being a stub definition anymore

## Checklist

- [ ] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [x] Ready for review 🚀
