### PR TITLE
ci: 🚚 rename release step to pre-release

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: 🔖 Github Release (Tag + Release)
+      - name: 🔖 Github Pre-release (Tag + Pre-release)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Description

- In pre-release job, name step to `🔖 Github Pre-release (Tag + Pre-release)`

## Related Issues

- In pre-release job, the step to create a pre-release had a misleading name

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

N/A

## Checklist

- [ ] Code follows project style guidelines
- [ ] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
