### PR TITLE
ci(dependabot): 🤖 setup initial dependabot config

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -30,6 +30,7 @@ const commitlintConfig: UserConfig = {
       [
         "setup", // Project setup
         "config", // Configuration files
+        "dependabot", // Dependabot configuration
         "deps", // Dependency updates
         "feature", // Feature-specific changes
         "bug", // Bug fixes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily" # Check the npm registry for updates every day (weekdays)


### PR DESCRIPTION
## Description

- configure initial dependabot setup to set the directory as `/`, allowing dependabot to detect project workspaces, check for security vulnerabilities, and update `pnpm-lock.yaml`.

See relevant sources:
- https://github.com/dependabot/dependabot-core/issues/10758
- https://github.com/dependabot/dependabot-core/issues/11135
- https://github.com/dependabot/dependabot-core/pull/11487

## Related issues

- dependabot isn't creating PRs for security updates to packages and `pnpm-lock.yaml`.

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

See dependabot PR in forked repo with dependabot config - It updates `pnpm-lock.yaml`
https://github.com/ktn1234/maiar-ai/pull/11

## Checklist

- [ ] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [x] Ready for review 🚀
