### PR TITLE
ci(ci,bug): 🐛 switch to pull_request_target for Nx Cloud integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@
 name: ♻️ CI Workflow
 run-name: "♻️ CI Workflow - PR #${{ github.event.pull_request.number }} commit ${{ github.sha }} by @${{ github.actor }}"
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - "*"
 

--- a/nx.json
+++ b/nx.json
@@ -27,9 +27,14 @@
         "{workspaceRoot}/tsconfig.base.json",
         "{projectRoot}/tsconfig.json"
       ],
+      "outputs": [],
       "cache": true
     },
-    "lint": { "inputs": ["{workspaceRoot}/eslint.config.js"], "cache": true }
+    "lint": {
+      "inputs": ["{workspaceRoot}/eslint.config.js"],
+      "outputs": [],
+      "cache": true
+    }
   },
   "parallel": 20,
   "plugins": [


### PR DESCRIPTION
## Description

This PR updates the CI workflows to use the `pull_request_target` event instead of `pull_request`. This change allows workflows to access repository secrets, such as `NX_CLOUD_ACCESS_TOKEN`, which are necessary for Nx Cloud integration during CI runs.

## Related Issues

Previously, workflows triggered by `pull_request` from forks did not have access to repository secrets, leading to failures in Nx Cloud integration. Switching to `pull_request_target` ensures that workflows have the required permissions to access secrets and perform necessary actions in the base repository.

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

N/A

## Checklist

- [ ] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [x] Ready for review 🚀
