### PR TITLE
ci(dependabot): 🔧 assign open-pull-requests-limit to 0 to disable version updates for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    open-pull-requests-limit: 0 # Disable version updates for npm dependencies
     directory: "/"
     schedule:
       interval: "daily" # Check the npm registry for updates every day (weekdays)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily" # Check the npm registry for updates every day (weekdays)
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Description

- Set open-pull-requests-limit: 0 in Dependabot config to effectively block all normal version bump PRs.
- Prevents Dependabot from opening PRs for regular dependency updates.
- Ensures only security-related updates (via security advisories) will trigger PRs.
- Reduces noise and manual PR triage.

Source - https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file

## Related Issues

- Configure Dependabot to only create PRs for high severity security vulnerabilities in NPM dependencies.
Do not allow automatic version bumps for normal updates; manual updates will be handled separately.

Acceptance Criteria:
- No PRs for version bumps unless tied to a security advisory.
- Security PRs should be created automatically when vulnerabilities are detected.
- Minimal/no noise from non-security updates.

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [x] Code refactored
- [ ] Documentation updated

## How to Test

N/A

## Checklist

- [x] Code follows project style guidelines
- [ ] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [x] Ready for review 🚀
