### PR TITLE
ci: 👷 add stale issue/PR workflow for automatic marking and closure

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,30 @@
+name: ⏳ Stale Issues & PRs
+run-name: ⏳ Stale Issues & PRs - Mark and close stale issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs every day at midnight UTC
+
+env:
+  DAYS_BEFORE_STALE: 30
+  DAYS_BEFORE_CLOSE: 7
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue is stale because it has been open for ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove the stale label, comment, or it will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days."
+          stale-pr-message: "This PR is stale because it has been open for ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove the stale label, comment, or it will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days."
+          close-issue-message: "This issue was closed because it has been stale for ${{ env.DAYS_BEFORE_STALE }} days with no activity. If this is a mistake, please comment and we will reopen it."
+          close-pr-message: "This PR was closed because it has been stale for ${{ env.DAYS_BEFORE_STALE }} days with no activity. If this is a mistake, please comment and we will reopen it."
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}


### PR DESCRIPTION
## Description

- Added a new workflow for stale issues and PRs
- This workflow automatically marks issues and PRs as stale after 30 days of inactivity and closes them 7 days later if no activity occurs. It uses the [actions/stale](https://github.com/actions/stale) GitHub Action for labeling and closing stale items, with clear messages notifying users. This ensures better maintenance of the repo by automatically cleaning up inactive issues and PRs.

## Related Issues

- Inactive issues and PRs often accumulate in repositories, leading to clutter and inefficiency. Without automated management, maintainers must manually track and close outdated items, which can be time-consuming and error-prone. This results in a less organized repository, where relevant tasks may get overlooked or buried under irrelevant, stale issues and PRs.

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

N/A

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
