### PR TITLE
ci(nx): 🔧 add NX_NO_CLOUD env var to ci/pre-release/release/publish workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ env:
   CI: ${{ vars.CI }}
   HUSKY: ${{ vars.HUSKY }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_NO_CLOUD: ${{ vars.NX_NO_CLOUD }}
 
 permissions:
   contents: read # Needed for the checkout action

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -20,6 +20,8 @@ concurrency:
 env:
   CI: ${{ vars.CI }}
   HUSKY: ${{ vars.HUSKY }}
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_NO_CLOUD: ${{ vars.NX_NO_CLOUD }}
 
 permissions:
   contents: write # Needed for the checkout action and to create a release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,7 @@ env:
   CI: ${{ vars.CI }}
   HUSKY: ${{ vars.HUSKY }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_NO_CLOUD: ${{ vars.NX_NO_CLOUD }}
 
 jobs:
   publish-npm-package:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ env:
   CI: ${{ vars.CI }}
   HUSKY: ${{ vars.HUSKY }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_NO_CLOUD: ${{ vars.NX_NO_CLOUD }}
 
 permissions:
   contents: write # Needed for the checkout action and to create a release


### PR DESCRIPTION
## Description

- Adds `NX_NO_CLOUD` env var to ci/pre-release/release/publish workflows
   - This allows us to disable the env var using Github repo action's vars when we run out of Nx credits

## Related Issues

Failed build bc Nx Cloud organization has been disabled due to exceeding the FREE plan.
- https://github.com/UraniumCorporation/maiar-ai/actions/runs/14749305162/job/41402800784

```
NX   Connection to Nx Cloud failed with status code 401

This Nx Cloud organization has been disabled due to exceeding the FREE plan.
An organization admin can start a free two week PRO plan trial with no billing required at https://cloud.nx.app/orgs/680680a3fd4eb5799867a987/plans.


 NX   Nx Cloud: Workspace is unable to be authorized. Exiting run.

This Nx Cloud organization has been disabled due to exceeding the FREE plan.
An organization admin can start a free two week PRO plan trial with no billing required at https://cloud.nx.app/orgs/680680a3fd4eb5799867a987/plans.

 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Check forked repo CI workflow run:
https://github.com/ktn1234/maiar-ai/actions/runs/14749569968/job/41403624491

```
 NX   Nx Cloud manually disabled

Nx will continue running, but nothing will be written or read from the remote cache.
Run details will also not be available in the Nx Cloud UI.

If this wasn't intentional, check for the NX_NO_CLOUD environment variable or the --no-cloud flag.
```

## Checklist

- [ ] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [x] Ready for review 🚀
