### PR TITLE
chore(config): 🔧 dynamically extend scope-enum with package and app dirs

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -1,4 +1,9 @@
 import type { UserConfig } from "@commitlint/types";
+import { readdirSync } from "fs";
+import { join } from "path";
+
+const packages = readdirSync(join(__dirname, "packages"));
+const apps = readdirSync(join(__dirname, "apps"));
 
 const commitlintConfig: UserConfig = {
   extends: ["@commitlint/config-conventional"],
@@ -46,32 +51,13 @@ const commitlintConfig: UserConfig = {
         "bounty", // Bounty CI related changes
         "thank-you", // Thank you CI related changes
         "other", // Other changes
-        "packages", // packages directory
-        "core", // core package
+        "packages", // packages directory,
+        ...packages, // all packages
         "memory", // memory provider
-        "memory-filesystem", // memory-filesystem memory provider
-        "memory-postgres", // memory-postgres memory provider
-        "memory-sqlite", // memory-sqlite memory provider
         "model", // model provider
-        "model-ollama", // model-ollama model provider
-        "model-openai", // model-openai model provider
         "plugin", // plugin provider
-        "plugin-character", // plugin-character plugin
-        "plugin-codex", // plugin-codex plugin
-        "plugin-discord", // plugin-discord plugin
-        "plugin-image", // plugin-image plugin
-        "plugin-mcp", // plugin-mcp plugin
-        "plugin-search", // plugin-search plugin
-        "plugin-telegram", // plugin-telegram plugin
-        "plugin-terminal", // plugin-terminal plugin
-        "plugin-text", // plugin-text plugin
-        "plugin-time", // plugin-time plugin
-        "plugin-websocket", // plugin-websocket plugin,
-        "plugin-x", // plugin-x plugin
         "apps", // apps directory
-        "client", // maiar client app
-        "starter", // maiar starter app
-        "website", // maiar docs website app
+        ...apps, // all apps
         "nx", // nx related changes
         "docker" // docker related changes
       ]


### PR DESCRIPTION
## Description

This update enhances the `commitlint` config by dynamically loading all directory names from `packages/*` and `apps/*`, appending them to the allowed scope-enum list—ensuring commit scopes remain valid and project-aware without manual updates.

## Related Issues

- Hard-coded scopes for packages/* and apps/*

## Changes Made

- [ ] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

```
git commit -m --allow-empty "chore(core): test"
pnpm commitlint
```

## Checklist

- [ ] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [ ] Documentation has been updated if necessary
- [x] Ready for review 🚀
