### PR TITLE
ci(release): 👷 add rollback gha workflow to rollback to a specific commit hash

### DIFF
--- a/.github/workflows/bounty.yaml
+++ b/.github/workflows/bounty.yaml
@@ -19,10 +19,7 @@ jobs:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
 
-      - name: 📦 Install dependencies
-        run: |
-          npm install -g pnpm
-          pnpm install -w --save-exact @actions/github@6.0.0
+      - uses: ./.github/actions/setup
 
       # Step Outputs:
       # - issues_closed (string) - "1, 2, 3" (csv) or ""

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -1,0 +1,71 @@
+---
+name: 🔙 Rollback
+run-name: 🔙 Rollback to ${{ inputs.commit }} Commit Hash by ${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit hash to rollback to (only the first 7 characters are needed)"
+        type: string
+        required: true
+
+permissions:
+  contents: write # Needed for the checkout action and to delete a release
+
+jobs:
+  rollback:
+    name: 🔙 Rollback to ${{ inputs.commit }} Commit Hash
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔑 Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: 🛒 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all tags
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: 🔧 Configure Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: 🔎 Validate Rollback Commit Exists
+        run: |
+          if ! git cat-file -e "${{ inputs.commit }}^{commit}"; then
+            echo "❌ Commit ${{ inputs.commit }} not found"
+            exit 1
+          fi
+
+      - name: 💣 Delete tags and GitHub Releases after Rollback Commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          { git log --pretty=format:"%H" ${{ inputs.commit }}..HEAD; echo; } | while read commit; do
+            if [ -n "$commit" ]; then
+              tags=$(git tag --points-at "$commit")
+              if [ -n "$tags" ]; then
+                for tag in $tags; do
+                  echo "Deleting tag $tag and its associated release"
+                  git push --delete origin "$tag"
+                  git tag -d "$tag"
+                  gh release delete "$tag" -y || echo "No release found for $tag, skipping..."
+                done
+              else
+                echo "No tags found for commit $commit"
+              fi
+            else
+              echo "Skipping empty commit hash..."
+            fi
+          done
+
+      - name: 🧨 Force reset and push
+        run: |
+          git reset --hard "${{ inputs.commit }}"
+          git push origin HEAD --force

--- a/.github/workflows/thank-you.yaml
+++ b/.github/workflows/thank-you.yaml
@@ -14,10 +14,7 @@ jobs:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
 
-      - name: 📦 Install dependencies
-        run: |
-          npm install -g pnpm
-          pnpm install -w --save-exact @actions/github@6.0.0
+      - uses: ./.github/actions/setup
 
       - name: 🎉 Thank Contributor
         run: node .github/scripts/thank-you/thank-contributor.js

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "docker:clogs": "docker compose logs -f"
   },
   "devDependencies": {
+    "@actions/github": "6.0.0",
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-conventional": "19.6.0",
     "@commitlint/format": "19.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@actions/github':
+        specifier: 6.0.0
+        version: 6.0.0
       '@commitlint/cli':
         specifier: 19.6.1
         version: 19.6.1(@types/node@22.13.1)(typescript@5.7.3)
@@ -25,13 +28,13 @@ importers:
         version: 9.19.0
       '@nx/eslint':
         specifier: 20.8.0
-        version: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(eslint@9.21.0)(nx@20.8.0)
+        version: 20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(eslint@9.21.0(jiti@2.4.2))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/js':
         specifier: 20.8.0
-        version: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(nx@20.8.0)
+        version: 20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@swc-node/register':
         specifier: 1.9.1
-        version: 1.9.1(@swc/core@1.5.7)(@swc/types@0.1.21)(typescript@5.7.3)
+        version: 1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3)
       '@swc/core':
         specifier: 1.5.7
         version: 1.5.7(@swc/helpers@0.5.11)
@@ -55,25 +58,25 @@ importers:
         version: 3.3.0(@types/node@22.13.1)(typescript@5.7.3)
       eslint-config-prettier:
         specifier: 10.0.1
-        version: 10.0.1(eslint@9.21.0)
+        version: 10.0.1(eslint@9.21.0(jiti@2.4.2))
       husky:
         specifier: 9.1.7
         version: 9.1.7
       nx:
         specifier: 20.8.0
-        version: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+        version: 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       prettier:
         specifier: 3.4.2
         version: 3.4.2
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
       typescript-eslint:
         specifier: 8.22.0
-        version: 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+        version: 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
 
   apps/client:
     dependencies:
@@ -82,19 +85,19 @@ importers:
         version: 11.14.0(@types/react@19.0.10)(react@19.0.0)
       '@emotion/styled':
         specifier: 11.14.0
-        version: 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@fontsource/roboto':
         specifier: 5.1.1
         version: 5.1.1
       '@mui/icons-material':
         specifier: 6.4.6
-        version: 6.4.6(@mui/material@6.4.6)(@types/react@19.0.10)(react@19.0.0)
+        version: 6.4.6(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@mui/lab':
         specifier: 6.0.0-beta.29
-        version: 6.0.0-beta.29(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@mui/material@6.4.6)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
+        version: 6.0.0-beta.29(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/material':
         specifier: 6.4.6
-        version: 6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
+        version: 6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -103,13 +106,13 @@ importers:
         version: 19.0.0(react@19.0.0)
       react-grid-layout:
         specifier: 1.5.0
-        version: 1.5.0(react-dom@19.0.0)(react@19.0.0)
+        version: 1.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-virtualized-auto-sizer:
         specifier: 1.0.26
-        version: 1.0.26(react-dom@19.0.0)(react@19.0.0)
+        version: 1.0.26(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-window:
         specifier: 1.8.11
-        version: 1.8.11(react-dom@19.0.0)(react@19.0.0)
+        version: 1.8.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@eslint/js':
         specifier: 9.21.0
@@ -128,16 +131,16 @@ importers:
         version: 1.8.8
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@6.2.7)
+        version: 4.3.4(vite@6.2.7(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1))
       eslint:
         specifier: 9.21.0
-        version: 9.21.0
+        version: 9.21.0(jiti@2.4.2)
       eslint-plugin-react-hooks:
         specifier: 5.1.0
-        version: 5.1.0(eslint@9.21.0)
+        version: 5.1.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-react-refresh:
         specifier: 0.4.19
-        version: 0.4.19(eslint@9.21.0)
+        version: 0.4.19(eslint@9.21.0(jiti@2.4.2))
       globals:
         specifier: 15.15.0
         version: 15.15.0
@@ -146,10 +149,10 @@ importers:
         version: 5.7.3
       typescript-eslint:
         specifier: 8.24.1
-        version: 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+        version: 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       vite:
         specifier: 6.2.7
-        version: 6.2.7(@types/node@22.13.1)
+        version: 6.2.7(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1)
 
   apps/starter:
     dependencies:
@@ -234,7 +237,7 @@ importers:
         version: 8.0.0
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -243,13 +246,13 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/plugin-pwa':
         specifier: 3.7.0
-        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/babel__core@7.20.5)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/preset-classic':
         specifier: 3.7.0
-        version: 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+        version: 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
       '@mdx-js/react':
         specifier: 3.1.0
         version: 3.1.0(@types/react@19.0.8)(react@19.0.0)
@@ -267,17 +270,17 @@ importers:
         version: 19.0.0(react@19.0.0)
       react-glitch-effect:
         specifier: 3.1.0
-        version: 3.1.0(react-dom@19.0.0)(react@19.0.0)
+        version: 3.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.7.0
-        version: 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+        version: 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/tsconfig':
         specifier: 3.7.0
         version: 3.7.0
       '@docusaurus/types':
         specifier: 3.7.0
-        version: 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+        version: 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/node':
         specifier: 22.13.1
         version: 22.13.1
@@ -289,7 +292,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       docusaurus-plugin-typedoc:
         specifier: 1.2.3
-        version: 1.2.3(typedoc-plugin-markdown@4.4.1)
+        version: 1.2.3(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.7.3)))
       pwa-asset-generator:
         specifier: 8.0.4
         version: 8.0.4
@@ -298,7 +301,7 @@ importers:
         version: 0.27.6(typescript@5.7.3)
       typedoc-plugin-markdown:
         specifier: 4.4.1
-        version: 4.4.1(typedoc@0.27.6)
+        version: 4.4.1(typedoc@0.27.6(typescript@5.7.3))
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -344,7 +347,7 @@ importers:
         version: 8.18.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -372,7 +375,7 @@ importers:
         version: 8.11.11
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -397,7 +400,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -416,7 +419,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -438,7 +441,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -457,7 +460,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -469,7 +472,7 @@ importers:
         version: link:../core
       '@openai/codex':
         specifier: 0.1.2504211509
-        version: 0.1.2504211509
+        version: 0.1.2504211509(@types/react@19.0.10)(ws@8.18.1)
       execa:
         specifier: 9.3.1
         version: 9.3.1
@@ -479,7 +482,7 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -501,7 +504,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -523,7 +526,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -545,7 +548,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -567,7 +570,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -589,7 +592,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -611,7 +614,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -636,7 +639,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -652,7 +655,7 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -674,7 +677,7 @@ importers:
         version: 8.5.14
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -699,12 +702,18 @@ importers:
         version: 22.13.1
       tsup:
         specifier: 8.3.6
-        version: 8.3.6(@swc/core@1.5.7)(typescript@5.7.3)
+        version: 8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
 
 packages:
+
+  '@actions/github@6.0.0':
+    resolution: {integrity: sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==}
+
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
 
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
@@ -2345,6 +2354,10 @@ packages:
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@floating-ui/core@1.6.9':
     resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
 
@@ -2678,6 +2691,54 @@ packages:
 
   '@nx/workspace@20.8.0':
     resolution: {integrity: sha512-FdaHA5ISHSN+RyHswAAx+2A9HC77kWeFgeucdX2NSBs2QK2Lzg2Et639RzR1sYk2gYTP6tOkQXHHGKcg3jmiYQ==}
+
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@5.2.1':
+    resolution: {integrity: sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@7.1.1':
+    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@20.0.0':
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/plugin-paginate-rest@9.2.2':
+    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1':
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@12.6.0':
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
@@ -3832,6 +3893,9 @@ packages:
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+
   better-sqlite3@11.8.1:
     resolution: {integrity: sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==}
 
@@ -4620,6 +4684,9 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -8824,6 +8891,10 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -8927,6 +8998,10 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@6.21.1:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
     engines: {node: '>=18.17'}
@@ -8983,6 +9058,9 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -9448,6 +9526,18 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@actions/github@6.0.0':
+    dependencies:
+      '@actions/http-client': 2.2.3
+      '@octokit/core': 5.2.1
+      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.1)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.1)
+
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.29.0
 
   '@alcalzone/ansi-tokenize@0.1.3':
     dependencies:
@@ -10400,7 +10490,7 @@ snapshots:
       '@commitlint/types': 19.8.0
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.7.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0)(typescript@5.7.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -10456,22 +10546,22 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.4.1
 
-  '@csstools/cascade-layer-name-parser@2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/cascade-layer-name-parser@2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/color-helpers@5.0.2': {}
 
-  '@csstools/css-calc@2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/css-calc@2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
-  '@csstools/css-color-parser@3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/css-color-parser@3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/color-helpers': 5.0.2
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
@@ -10481,7 +10571,7 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.3': {}
 
-  '@csstools/media-query-list-parser@4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/media-query-list-parser@4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
@@ -10494,7 +10584,7 @@ snapshots:
 
   '@csstools/postcss-color-function@4.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -10503,7 +10593,7 @@ snapshots:
 
   '@csstools/postcss-color-mix-function@3.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -10520,7 +10610,7 @@ snapshots:
 
   '@csstools/postcss-exponential-functions@2.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -10533,14 +10623,14 @@ snapshots:
 
   '@csstools/postcss-gamut-mapping@2.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
   '@csstools/postcss-gradients-interpolation-method@5.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -10549,7 +10639,7 @@ snapshots:
 
   '@csstools/postcss-hwb-function@4.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -10606,17 +10696,17 @@ snapshots:
 
   '@csstools/postcss-media-minmax@2.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
   '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.5.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
   '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.3)':
@@ -10632,7 +10722,7 @@ snapshots:
 
   '@csstools/postcss-oklab-function@4.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -10646,14 +10736,14 @@ snapshots:
 
   '@csstools/postcss-random-function@1.0.3(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
   '@csstools/postcss-relative-color-syntax@3.0.8(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -10667,14 +10757,14 @@ snapshots:
 
   '@csstools/postcss-sign-functions@1.1.2(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
 
   '@csstools/postcss-stepped-value-functions@4.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -10687,7 +10777,7 @@ snapshots:
 
   '@csstools/postcss-trigonometric-functions@4.0.7(postcss@8.5.3)':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -10765,20 +10855,21 @@ snapshots:
 
   '@docsearch/css@3.9.0': {}
 
-  '@docsearch/react@3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)':
+  '@docsearch/react@3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.23.4)(algoliasearch@5.23.4)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.23.4)(algoliasearch@5.23.4)
       '@docsearch/css': 3.9.0
-      '@types/react': 19.0.8
       algoliasearch: 5.23.4
+    optionalDependencies:
+      '@types/react': 19.0.8
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/babel@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/generator': 7.27.0
@@ -10791,7 +10882,7 @@ snapshots:
       '@babel/runtime-corejs3': 7.27.0
       '@babel/traverse': 7.27.0
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.0
       tslib: 2.8.1
@@ -10805,33 +10896,33 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/bundler@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.26.10
-      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/cssnano-preset': 3.7.0
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.99.6)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.99.6)
-      css-loader: 6.11.0(webpack@5.99.6)
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6)
+      copy-webpack-plugin: 11.0.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      css-loader: 6.11.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       cssnano: 6.1.2(postcss@8.5.3)
-      file-loader: 6.2.0(webpack@5.99.6)
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.9.2(webpack@5.99.6)
-      null-loader: 4.0.1(webpack@5.99.6)
+      mini-css-extract-plugin: 2.9.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      null-loader: 4.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       postcss: 8.5.3
-      postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6)
+      postcss-loader: 7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       postcss-preset-env: 10.1.5(postcss@8.5.3)
-      react-dev-utils: 12.0.1(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6)
-      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.99.6)
+      react-dev-utils: 12.0.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.99.6)
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
-      webpackbar: 6.0.1(webpack@5.99.6)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+      webpackbar: 6.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -10850,15 +10941,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/bundler': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/babel': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/bundler': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mdx-js/react': 3.1.0(@types/react@19.0.8)(react@19.0.0)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -10874,28 +10965,28 @@ snapshots:
       eval: 0.1.8
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(webpack@5.99.6)
+      html-webpack-plugin: 5.6.3(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       leven: 3.1.0
       lodash: 4.17.21
       p-map: 4.0.0
       prompts: 2.4.2
       react: 19.0.0
-      react-dev-utils: 12.0.1(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6)
+      react-dev-utils: 12.0.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       react-dom: 19.0.0(react@19.0.0)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)'
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.0.0)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.99.6)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       react-router: 5.3.4(react@19.0.0)
-      react-router-config: 5.1.1(react-router@5.3.4)(react@19.0.0)
+      react-router-config: 5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0)
       react-router-dom: 5.3.4(react@19.0.0)
       semver: 7.7.1
       serve-handler: 6.1.6
       shelljs: 0.8.5
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(webpack@5.99.6)
+      webpack-dev-server: 4.15.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -10929,16 +11020,16 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/mdx-loader@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.3.3
-      file-loader: 6.2.0(webpack@5.99.6)
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       fs-extra: 11.3.0
       image-size: 1.2.1
       mdast-util-mdx: 3.0.0
@@ -10954,9 +11045,9 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.99.6)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       vfile: 6.0.3
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@swc/core'
       - acorn
@@ -10965,16 +11056,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/module-type-aliases@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/history': 4.7.11
       '@types/react': 19.0.10
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)'
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.0.0)'
     transitivePeerDependencies:
       - '@swc/core'
@@ -10984,17 +11075,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.0
@@ -11006,7 +11097,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11028,17 +11119,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.0
@@ -11048,7 +11139,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11070,18 +11161,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11103,11 +11194,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -11134,11 +11225,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -11163,11 +11254,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/gtag.js': 0.0.12
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -11193,11 +11284,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
@@ -11222,27 +11313,27 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-pwa@3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-pwa@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/babel__core@7.20.5)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
-      '@docusaurus/bundler': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/bundler': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/theme-translations': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.99.6)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       clsx: 2.1.1
       core-js: 3.41.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
       webpack-merge: 5.10.0
-      workbox-build: 7.3.0
+      workbox-build: 7.3.0(@types/babel__core@7.20.5)
       workbox-precaching: 7.3.0
       workbox-window: 7.3.0
     transitivePeerDependencies:
@@ -11268,14 +11359,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -11302,18 +11393,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/webpack': 8.1.0(typescript@5.7.3)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       tslib: 2.8.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -11335,22 +11426,22 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
+  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-classic': 3.7.0(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-classic': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
@@ -11382,21 +11473,21 @@ snapshots:
       '@types/react': 19.0.10
       react: 19.0.0
 
-  '@docusaurus/theme-classic@3.7.0(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)':
+  '@docusaurus/theme-classic@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/theme-translations': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mdx-js/react': 3.1.0(@types/react@19.0.8)(react@19.0.0)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -11433,13 +11524,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/mdx-loader': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/module-type-aliases': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/history': 4.7.11
       '@types/react': 19.0.10
       '@types/react-router-config': 5.0.11
@@ -11458,16 +11549,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
+  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/react@19.0.8)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)(typescript@5.7.3)':
     dependencies:
-      '@docsearch/react': 3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0)(react@19.0.0)(search-insights@2.17.3)
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
+      '@docsearch/react': 3.9.0(@algolia/client-search@5.23.4)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(search-insights@2.17.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0)(react-dom@19.0.0)(react@19.0.0)(typescript@5.7.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0)(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(eslint@9.21.0(jiti@2.4.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/theme-translations': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-validation': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       algoliasearch: 5.23.4
       algoliasearch-helper: 3.24.3(algoliasearch@5.23.4)
       clsx: 2.1.1
@@ -11509,7 +11600,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.7.0': {}
 
-  '@docusaurus/types@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/types@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@types/history': 4.7.11
@@ -11518,9 +11609,9 @@ snapshots:
       joi: 17.13.3
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)'
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)'
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -11530,9 +11621,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/utils-common@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -11544,11 +11635,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/utils-validation@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/utils': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fs-extra: 11.3.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -11564,13 +11655,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)':
+  '@docusaurus/utils@3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
-      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7)(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0)(react@19.0.0)
+      '@docusaurus/types': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@docusaurus/utils-common': 3.7.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(acorn@8.14.1)(esbuild@0.24.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       escape-string-regexp: 4.0.0
-      file-loader: 6.2.0(webpack@5.99.6)
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       fs-extra: 11.3.0
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -11583,9 +11674,9 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.99.6)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       utility-types: 3.11.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - '@swc/core'
       - acorn
@@ -11650,9 +11741,10 @@ snapshots:
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
-      '@types/react': 19.0.10
       hoist-non-react-statics: 3.3.2
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
     transitivePeerDependencies:
       - supports-color
 
@@ -11666,7 +11758,7 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/babel-plugin': 11.13.5
@@ -11675,8 +11767,9 @@ snapshots:
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
       '@emotion/utils': 1.4.2
-      '@types/react': 19.0.10
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
     transitivePeerDependencies:
       - supports-color
 
@@ -11840,9 +11933,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.6.1(eslint@9.21.0)':
+  '@eslint-community/eslint-utils@4.6.1(eslint@9.21.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -11888,6 +11981,8 @@ snapshots:
       '@eslint/core': 0.13.0
       levn: 0.4.1
 
+  '@fastify/busboy@2.1.1': {}
+
   '@floating-ui/core@1.6.9':
     dependencies:
       '@floating-ui/utils': 0.2.9
@@ -11897,7 +11992,7 @@ snapshots:
       '@floating-ui/core': 1.6.9
       '@floating-ui/utils': 0.2.9
 
-  '@floating-ui/react-dom@2.1.2(react-dom@19.0.0)(react@19.0.0)':
+  '@floating-ui/react-dom@2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       react: 19.0.0
@@ -11932,13 +12027,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@inkjs/ui@2.0.0(ink@5.2.0)':
+  '@inkjs/ui@2.0.0(ink@5.2.0(@types/react@19.0.10)(react@18.3.1))':
     dependencies:
       chalk: 5.4.1
       cli-spinners: 3.2.0
       deepmerge: 4.3.1
       figures: 6.1.0
-      ink: 5.2.0(react@18.3.1)
+      ink: 5.2.0(@types/react@19.0.10)(react@18.3.1)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -12037,55 +12132,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mui/base@5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)':
+  '@mui/base@5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0)(react@19.0.0)
+      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/types': 7.4.1(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
       '@popperjs/core': 2.11.8
-      '@types/react': 19.0.10
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
 
   '@mui/core-downloads-tracker@6.4.11': {}
 
-  '@mui/icons-material@6.4.6(@mui/material@6.4.6)(@types/react@19.0.10)(react@19.0.0)':
+  '@mui/icons-material@6.4.6(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@mui/material': 6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
-      '@types/react': 19.0.10
+      '@mui/material': 6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
 
-  '@mui/lab@6.0.0-beta.29(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@mui/material@6.4.6)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)':
+  '@mui/lab@6.0.0-beta.29(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
-      '@mui/base': 5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
-      '@mui/material': 6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)
-      '@mui/system': 6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@19.0.0)
+      '@mui/base': 5.0.0-beta.69(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mui/material': 6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@mui/types': 7.4.1(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@types/react': 19.0.10
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
+      '@types/react': 19.0.10
 
-  '@mui/material@6.4.6(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react-dom@19.0.0)(react@19.0.0)':
+  '@mui/material@6.4.6(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
       '@mui/core-downloads-tracker': 6.4.11
-      '@mui/system': 6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@19.0.0)
+      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
       '@mui/types': 7.4.1(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
       '@popperjs/core': 2.11.8
-      '@types/react': 19.0.10
       '@types/react-transition-group': 4.4.12(@types/react@19.0.10)
       clsx: 2.1.1
       csstype: 3.1.3
@@ -12093,50 +12188,58 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-is: 19.1.0
-      react-transition-group: 4.4.5(react-dom@19.0.0)(react@19.0.0)
+      react-transition-group: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
+      '@types/react': 19.0.10
 
   '@mui/private-theming@6.4.9(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@types/react': 19.0.10
       prop-types: 15.8.1
       react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
 
-  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@19.0.0)':
+  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 19.0.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
 
-  '@mui/system@6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@19.0.10)(react@19.0.0)':
+  '@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@19.0.10)(react@19.0.0)
       '@mui/private-theming': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@19.0.0)
+      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0))(react@19.0.0)
       '@mui/types': 7.2.24(@types/react@19.0.10)
       '@mui/utils': 6.4.9(@types/react@19.0.10)(react@19.0.0)
-      '@types/react': 19.0.10
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 19.0.0
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.0.10)(react@19.0.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.10)(react@19.0.0))(@types/react@19.0.10)(react@19.0.0)
+      '@types/react': 19.0.10
 
   '@mui/types@7.2.24(@types/react@19.0.10)':
-    dependencies:
+    optionalDependencies:
       '@types/react': 19.0.10
 
   '@mui/types@7.4.1(@types/react@19.0.10)':
     dependencies:
       '@babel/runtime': 7.27.0
+    optionalDependencies:
       '@types/react': 19.0.10
 
   '@mui/utils@6.4.9(@types/react@19.0.10)(react@19.0.0)':
@@ -12144,11 +12247,12 @@ snapshots:
       '@babel/runtime': 7.27.0
       '@mui/types': 7.2.24(@types/react@19.0.10)
       '@types/prop-types': 15.7.14
-      '@types/react': 19.0.10
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.0.0
       react-is: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.0.10
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -12168,26 +12272,28 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nx/devkit@20.8.0(nx@20.8.0)':
+  '@nx/devkit@20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))':
     dependencies:
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+      nx: 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       semver: 7.7.1
       tmp: 0.2.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(eslint@9.21.0)(nx@20.8.0)':
+  '@nx/eslint@20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@zkochan/js-yaml@0.0.7)(eslint@9.21.0(jiti@2.4.2))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))':
     dependencies:
-      '@nx/devkit': 20.8.0(nx@20.8.0)
-      '@nx/js': 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(nx@20.8.0)
-      eslint: 9.21.0
+      '@nx/devkit': 20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
+      '@nx/js': 20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
+      eslint: 9.21.0(jiti@2.4.2)
       semver: 7.7.1
       tslib: 2.8.1
       typescript: 5.7.3
+    optionalDependencies:
+      '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12197,7 +12303,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/js@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)(nx@20.8.0)':
+  '@nx/js@20.8.0(@babel/traverse@7.27.0)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
@@ -12206,12 +12312,12 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
       '@babel/runtime': 7.27.0
-      '@nx/devkit': 20.8.0(nx@20.8.0)
-      '@nx/workspace': 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+      '@nx/devkit': 20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
+      '@nx/workspace': 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       '@zkochan/js-yaml': 0.0.7
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.10)
       babel-plugin-macros: 3.1.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.10)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.10)(@babel/traverse@7.27.0)
       chalk: 4.1.2
       columnify: 1.6.0
       detect-port: 1.6.1
@@ -12266,13 +12372,13 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.8.0':
     optional: true
 
-  '@nx/workspace@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)':
+  '@nx/workspace@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))':
     dependencies:
-      '@nx/devkit': 20.8.0(nx@20.8.0)
+      '@nx/devkit': 20.8.0(nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@zkochan/js-yaml': 0.0.7
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7)
+      nx: 20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
       picomatch: 4.0.2
       tslib: 2.8.1
       yargs-parser: 21.1.1
@@ -12281,11 +12387,69 @@ snapshots:
       - '@swc/core'
       - debug
 
+  '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@5.2.1':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+
+  '@octokit/endpoint@9.0.6':
+    dependencies:
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/graphql@7.1.1':
+    dependencies:
+      '@octokit/request': 8.4.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/openapi-types@20.0.0': {}
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.1)':
+    dependencies:
+      '@octokit/core': 5.2.1
+      '@octokit/types': 12.6.0
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.1)':
+    dependencies:
+      '@octokit/core': 5.2.1
+      '@octokit/types': 12.6.0
+
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.10.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
+  '@octokit/request@8.4.1':
+    dependencies:
+      '@octokit/endpoint': 9.0.6
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/types@12.6.0':
+    dependencies:
+      '@octokit/openapi-types': 20.0.0
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
+
   '@one-ini/wasm@0.1.1': {}
 
-  '@openai/codex@0.1.2504211509':
+  '@openai/codex@0.1.2504211509(@types/react@19.0.10)(ws@8.18.1)':
     dependencies:
-      '@inkjs/ui': 2.0.0(ink@5.2.0)
+      '@inkjs/ui': 2.0.0(ink@5.2.0(@types/react@19.0.10)(react@18.3.1))
       chalk: 5.4.1
       diff: 7.0.0
       dotenv: 16.4.7
@@ -12293,13 +12457,13 @@ snapshots:
       fast-npm-meta: 0.4.2
       figures: 6.1.0
       file-type: 20.4.1
-      ink: 5.2.0(react@18.3.1)
+      ink: 5.2.0(@types/react@19.0.10)(react@18.3.1)
       js-yaml: 4.1.0
       marked: 15.0.9
       marked-terminal: 7.3.0(marked@15.0.9)
       meow: 13.2.0
       open: 10.1.1
-      openai: 4.95.1(zod@3.24.3)
+      openai: 4.95.1(ws@8.18.1)(zod@3.24.3)
       package-manager-detector: 1.2.0
       react: 18.3.1
       shell-quote: 1.8.2
@@ -12348,12 +12512,14 @@ snapshots:
       - bare-buffer
       - supports-color
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.26.10)(rollup@2.79.2)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@2.79.2)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-module-imports': 7.25.9
       '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
       rollup: 2.79.2
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
     transitivePeerDependencies:
       - supports-color
 
@@ -12364,6 +12530,7 @@ snapshots:
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
+    optionalDependencies:
       rollup: 2.79.2
 
   '@rollup/plugin-replace@2.4.2(rollup@2.79.2)':
@@ -12374,10 +12541,11 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@2.79.2)':
     dependencies:
-      rollup: 2.79.2
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.39.0
+    optionalDependencies:
+      rollup: 2.79.2
 
   '@rollup/pluginutils@3.1.0(rollup@2.79.2)':
     dependencies:
@@ -12391,6 +12559,7 @@ snapshots:
       '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 4.0.2
+    optionalDependencies:
       rollup: 2.79.2
 
   '@rollup/rollup-android-arm-eabi@4.40.0':
@@ -12492,7 +12661,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0)(react@19.0.0)':
+  '@slorber/react-helmet-async@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       invariant: 2.2.4
@@ -12575,7 +12744,7 @@ snapshots:
       '@babel/types': 7.27.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.7.3))':
     dependencies:
       '@babel/core': 7.26.10
       '@svgr/babel-preset': 8.1.0(@babel/core@7.26.10)
@@ -12585,7 +12754,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@5.7.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.7.3)
       cosmiconfig: 8.3.6(typescript@5.7.3)
@@ -12602,20 +12771,20 @@ snapshots:
       '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.27.0(@babel/core@7.26.10)
       '@svgr/core': 8.1.0(typescript@5.7.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.7.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@swc-node/core@1.13.3(@swc/core@1.5.7)(@swc/types@0.1.21)':
+  '@swc-node/core@1.13.3(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)':
     dependencies:
       '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       '@swc/types': 0.1.21
 
-  '@swc-node/register@1.9.1(@swc/core@1.5.7)(@swc/types@0.1.21)(typescript@5.7.3)':
+  '@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3)':
     dependencies:
-      '@swc-node/core': 1.13.3(@swc/core@1.5.7)(@swc/types@0.1.21)
+      '@swc-node/core': 1.13.3(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       colorette: 2.0.20
@@ -12665,7 +12834,6 @@ snapshots:
   '@swc/core@1.5.7(@swc/helpers@0.5.11)':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.11
       '@swc/types': 0.1.7
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.5.7
@@ -12678,6 +12846,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.5.7
       '@swc/core-win32-ia32-msvc': 1.5.7
       '@swc/core-win32-x64-msvc': 1.5.7
+      '@swc/helpers': 0.5.11
 
   '@swc/counter@0.1.3': {}
 
@@ -13004,15 +13173,15 @@ snapshots:
       '@types/node': 22.13.1
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/type-utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.22.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -13021,15 +13190,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1)(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/type-utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -13038,26 +13207,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.22.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.22.0
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.22.0
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.24.1(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.24.1
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -13072,23 +13241,23 @@ snapshots:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/visitor-keys': 8.24.1
 
-  '@typescript-eslint/type-utils@8.22.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.24.1(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       debug: 4.4.0
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -13126,24 +13295,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.22.0(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.22.0
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.24.1(eslint@9.21.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -13160,14 +13329,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.7)':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.7(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.7(@types/node@22.13.1)
+      vite: 6.2.7(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13309,7 +13478,7 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
-    dependencies:
+    optionalDependencies:
       ajv: 8.17.1
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -13474,12 +13643,12 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.99.6):
+  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.26.10):
     dependencies:
@@ -13524,10 +13693,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.10):
+  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.10)(@babel/traverse@7.27.0):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
+    optionalDependencies:
+      '@babel/traverse': 7.27.0
 
   bail@2.0.2: {}
 
@@ -13553,8 +13724,9 @@ snapshots:
 
   bare-stream@2.6.5(bare-events@2.5.4):
     dependencies:
-      bare-events: 2.5.4
       streamx: 2.22.0
+    optionalDependencies:
+      bare-events: 2.5.4
     optional: true
 
   base64-js@1.5.1: {}
@@ -13562,6 +13734,8 @@ snapshots:
   basic-ftp@5.0.5: {}
 
   batch@0.6.1: {}
+
+  before-after-hook@2.2.3: {}
 
   better-sqlite3@11.8.1:
     dependencies:
@@ -14103,7 +14277,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.0: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.99.6):
+  copy-webpack-plugin@11.0.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -14111,7 +14285,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   core-js-compat@3.41.0:
     dependencies:
@@ -14128,7 +14302,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0)(typescript@5.7.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@22.13.1)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
       '@types/node': 22.13.1
       cosmiconfig: 9.0.0(typescript@5.7.3)
@@ -14157,6 +14331,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.7.3
 
   cosmiconfig@9.0.0(typescript@5.7.3):
@@ -14165,6 +14340,7 @@ snapshots:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
       typescript: 5.7.3
 
   cross-spawn@7.0.6:
@@ -14195,7 +14371,7 @@ snapshots:
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(webpack@5.99.6):
+  css-loader@6.11.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -14205,19 +14381,21 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.3)
       postcss-value-parser: 4.2.0
       semver: 7.7.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+    optionalDependencies:
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.5.3)
-      esbuild: 0.24.2
       jest-worker: 29.7.0
       postcss: 8.5.3
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      clean-css: 5.3.3
+      esbuild: 0.24.2
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.3):
     dependencies:
@@ -14438,6 +14616,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  deprecation@2.3.1: {}
+
   dequal@2.0.3: {}
 
   destroy@1.2.0: {}
@@ -14502,9 +14682,9 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
-  docusaurus-plugin-typedoc@1.2.3(typedoc-plugin-markdown@4.4.1):
+  docusaurus-plugin-typedoc@1.2.3(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.7.3))):
     dependencies:
-      typedoc-plugin-markdown: 4.4.1(typedoc@0.27.6)
+      typedoc-plugin-markdown: 4.4.1(typedoc@0.27.6(typescript@5.7.3))
 
   dom-converter@0.2.0:
     dependencies:
@@ -14823,17 +15003,17 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.0.1(eslint@9.21.0):
+  eslint-config-prettier@10.0.1(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
 
-  eslint-plugin-react-hooks@5.1.0(eslint@9.21.0):
+  eslint-plugin-react-hooks@5.1.0(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
 
-  eslint-plugin-react-refresh@0.4.19(eslint@9.21.0):
+  eslint-plugin-react-refresh@0.4.19(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.21.0
+      eslint: 9.21.0(jiti@2.4.2)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -14849,9 +15029,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.21.0:
+  eslint@9.21.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0)
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.21.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.2
       '@eslint/core': 0.12.0
@@ -14885,6 +15065,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15138,7 +15320,7 @@ snapshots:
       pend: 1.2.0
 
   fdir@6.4.4(picomatch@4.0.2):
-    dependencies:
+    optionalDependencies:
       picomatch: 4.0.2
 
   fecha@4.2.3: {}
@@ -15166,11 +15348,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.99.6):
+  file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   file-type@20.4.1:
     dependencies:
@@ -15283,7 +15465,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@types/json-schema': 7.0.15
@@ -15291,7 +15473,6 @@ snapshots:
       chokidar: 3.6.0
       cosmiconfig: 6.0.0
       deepmerge: 4.3.1
-      eslint: 9.21.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.5.3
@@ -15300,7 +15481,9 @@ snapshots:
       semver: 7.7.1
       tapable: 1.1.3
       typescript: 5.7.3
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      eslint: 9.21.0(jiti@2.4.2)
 
   form-data-encoder@1.7.2: {}
 
@@ -15744,14 +15927,15 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.3(webpack@5.99.6):
+  html-webpack-plugin@5.6.3(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+    optionalDependencies:
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -15804,12 +15988,13 @@ snapshots:
 
   http-proxy-middleware@2.0.9(@types/express@4.17.21):
     dependencies:
-      '@types/express': 4.17.21
       '@types/http-proxy': 1.17.16
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
+    optionalDependencies:
+      '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
 
@@ -15899,7 +16084,7 @@ snapshots:
 
   ini@4.1.1: {}
 
-  ink@5.2.0(react@18.3.1):
+  ink@5.2.0(@types/react@19.0.10)(react@18.3.1):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.1.3
       ansi-escapes: 7.0.0
@@ -15926,6 +16111,8 @@ snapshots:
       wrap-ansi: 9.0.0
       ws: 8.18.1
       yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.0.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17047,11 +17234,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.99.6):
+  mini-css-extract-plugin@2.9.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   minimalistic-assert@1.0.1: {}
 
@@ -17191,17 +17378,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.99.6):
+  null-loader@4.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
-  nx@20.8.0(@swc-node/register@1.9.1)(@swc/core@1.5.7):
+  nx@20.8.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
-      '@swc-node/register': 1.9.1(@swc/core@1.5.7)(@swc/types@0.1.21)(typescript@5.7.3)
-      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
@@ -17246,6 +17431,8 @@ snapshots:
       '@nx/nx-linux-x64-musl': 20.8.0
       '@nx/nx-win32-arm64-msvc': 20.8.0
       '@nx/nx-win32-x64-msvc': 20.8.0
+      '@swc-node/register': 1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.21)(typescript@5.7.3)
+      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
     transitivePeerDependencies:
       - debug
 
@@ -17306,12 +17493,13 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+    optionalDependencies:
       ws: 8.18.1
       zod: 3.24.1
     transitivePeerDependencies:
       - encoding
 
-  openai@4.95.1(zod@3.24.3):
+  openai@4.95.1(ws@8.18.1)(zod@3.24.3):
     dependencies:
       '@types/node': 18.19.86
       '@types/node-fetch': 2.6.12
@@ -17320,6 +17508,8 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.1
       zod: 3.24.3
     transitivePeerDependencies:
       - encoding
@@ -17627,7 +17817,7 @@ snapshots:
 
   postcss-color-functional-notation@7.0.8(postcss@8.5.3):
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
@@ -17662,15 +17852,15 @@ snapshots:
 
   postcss-custom-media@11.0.5(postcss@8.5.3):
     dependencies:
-      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       postcss: 8.5.3
 
   postcss-custom-properties@14.0.4(postcss@8.5.3):
     dependencies:
-      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
@@ -17679,7 +17869,7 @@ snapshots:
 
   postcss-custom-selectors@8.0.4(postcss@8.5.3):
     dependencies:
-      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.3
@@ -17744,24 +17934,28 @@ snapshots:
 
   postcss-lab-function@7.0.8(postcss@8.5.3):
     dependencies:
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
       '@csstools/utilities': 2.0.0(postcss@8.5.3)
       postcss: 8.5.3
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.7.1):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.4.2
+      postcss: 8.5.3
+      yaml: 2.7.1
 
-  postcss-loader@7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6):
+  postcss-loader@7.3.4(postcss@8.5.3)(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.7.3)
       jiti: 1.21.7
       postcss: 8.5.3
       semver: 7.7.1
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - typescript
 
@@ -18253,7 +18447,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6):
+  react-dev-utils@12.0.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/code-frame': 7.26.2
       address: 1.2.2
@@ -18264,7 +18458,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.21.0)(typescript@5.7.3)(webpack@5.99.6)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -18279,8 +18473,9 @@ snapshots:
       shell-quote: 1.8.2
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
       typescript: 5.7.3
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -18291,7 +18486,7 @@ snapshots:
       react: 19.0.0
       scheduler: 0.25.0
 
-  react-draggable@4.4.6(react-dom@19.0.0)(react@19.0.0):
+  react-draggable@4.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       clsx: 1.2.1
       prop-types: 15.8.1
@@ -18302,21 +18497,21 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-glitch-effect@3.1.0(react-dom@19.0.0)(react@19.0.0):
+  react-glitch-effect@3.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  react-grid-layout@1.5.0(react-dom@19.0.0)(react@19.0.0):
+  react-grid-layout@1.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       clsx: 2.1.1
       fast-equals: 4.0.3
       prop-types: 15.8.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-draggable: 4.4.6(react-dom@19.0.0)(react@19.0.0)
-      react-resizable: 3.0.5(react-dom@19.0.0)(react@19.0.0)
+      react-draggable: 4.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-resizable: 3.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       resize-observer-polyfill: 1.5.1
 
   react-is@16.13.1: {}
@@ -18329,11 +18524,11 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.99.6):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.0.0))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@babel/runtime': 7.27.0
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.0.0)'
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
   react-reconciler@0.29.2(react@18.3.1):
     dependencies:
@@ -18343,15 +18538,15 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-resizable@3.0.5(react-dom@19.0.0)(react@19.0.0):
+  react-resizable@3.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       prop-types: 15.8.1
       react: 19.0.0
-      react-draggable: 4.4.6(react-dom@19.0.0)(react@19.0.0)
+      react-draggable: 4.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
 
-  react-router-config@5.1.1(react-router@5.3.4)(react@19.0.0):
+  react-router-config@5.1.1(react-router@5.3.4(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.27.0
       react: 19.0.0
@@ -18381,7 +18576,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-transition-group@4.4.5(react-dom@19.0.0)(react@19.0.0):
+  react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.27.0
       dom-helpers: 5.2.1
@@ -18390,12 +18585,12 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  react-virtualized-auto-sizer@1.0.26(react-dom@19.0.0)(react@19.0.0):
+  react-virtualized-auto-sizer@1.0.26(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  react-window@1.8.11(react-dom@19.0.0)(react@19.0.0):
+  react-window@1.8.11(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.27.0
       memoize-one: 5.2.1
@@ -19358,16 +19553,17 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.99.6):
+  terser-webpack-plugin@5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
-      esbuild: 0.24.2
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
+      esbuild: 0.24.2
 
   terser@5.39.0:
     dependencies:
@@ -19460,9 +19656,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.6(@swc/core@1.5.7)(typescript@5.7.3):
+  tsup@8.3.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(jiti@2.4.2)(postcss@8.5.3)(typescript@5.7.3)(yaml@2.7.1):
     dependencies:
-      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
       bundle-require: 5.1.0(esbuild@0.24.2)
       cac: 6.7.14
       chokidar: 4.0.3
@@ -19471,7 +19666,7 @@ snapshots:
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.7.1)
       resolve-from: 5.0.0
       rollup: 4.40.0
       source-map: 0.8.0-beta.0
@@ -19479,6 +19674,9 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
+      postcss: 8.5.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - jiti
@@ -19489,6 +19687,8 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  tunnel@0.0.6: {}
 
   type-check@0.4.0:
     dependencies:
@@ -19554,7 +19754,7 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typedoc-plugin-markdown@4.4.1(typedoc@0.27.6):
+  typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.7.3)):
     dependencies:
       typedoc: 0.27.6(typescript@5.7.3)
 
@@ -19567,22 +19767,22 @@ snapshots:
       typescript: 5.7.3
       yaml: 2.7.1
 
-  typescript-eslint@8.22.0(eslint@9.21.0)(typescript@5.7.3):
+  typescript-eslint@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.22.0(@typescript-eslint/parser@8.22.0)(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0)(typescript@5.7.3)
-      eslint: 9.21.0
+      '@typescript-eslint/eslint-plugin': 8.22.0(@typescript-eslint/parser@8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.24.1(eslint@9.21.0)(typescript@5.7.3):
+  typescript-eslint@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1)(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0)(typescript@5.7.3)
-      eslint: 9.21.0
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.21.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -19603,6 +19803,10 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.20.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@6.21.1: {}
 
@@ -19666,6 +19870,8 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
+  universal-user-agent@6.0.1: {}
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -19699,13 +19905,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0)(webpack@5.99.6):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)))(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
-      file-loader: 6.2.0(webpack@5.99.6)
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
 
   use-interval@1.4.0(react@18.3.1):
     dependencies:
@@ -19742,14 +19949,17 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@6.2.7(@types/node@22.13.1):
+  vite@6.2.7(@types/node@22.13.1)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1):
     dependencies:
-      '@types/node': 22.13.1
       esbuild: 0.25.2
       postcss: 8.5.3
       rollup: 4.40.0
     optionalDependencies:
+      '@types/node': 22.13.1
       fsevents: 2.3.3
+      jiti: 2.4.2
+      terser: 5.39.0
+      yaml: 2.7.1
 
   watchpack@2.4.2:
     dependencies:
@@ -19792,16 +20002,16 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@5.3.4(webpack@5.99.6):
+  webpack-dev-middleware@5.3.4(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
 
-  webpack-dev-server@4.15.2(webpack@5.99.6):
+  webpack-dev-server@4.15.2(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19831,9 +20041,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
-      webpack-dev-middleware: 5.3.4(webpack@5.99.6)
+      webpack-dev-middleware: 5.3.4(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       ws: 8.18.1
+    optionalDependencies:
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19854,7 +20065,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.99.6(@swc/core@1.5.7)(esbuild@0.24.2):
+  webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -19876,7 +20087,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7)(esbuild@0.24.2)(webpack@5.99.6)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -19884,7 +20095,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.99.6):
+  webpackbar@6.0.1(webpack@5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -19893,7 +20104,7 @@ snapshots:
       markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.9.0
-      webpack: 5.99.6(@swc/core@1.5.7)(esbuild@0.24.2)
+      webpack: 5.99.6(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.24.2)
       wrap-ansi: 7.0.0
 
   websocket-driver@0.7.4:
@@ -20013,13 +20224,13 @@ snapshots:
     dependencies:
       workbox-core: 7.3.0
 
-  workbox-build@7.3.0:
+  workbox-build@7.3.0(@types/babel__core@7.20.5):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
       '@babel/core': 7.26.10
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
       '@babel/runtime': 7.27.0
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.26.10)(rollup@2.79.2)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@2.79.2)
       '@rollup/plugin-node-resolve': 15.3.1(rollup@2.79.2)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)
       '@rollup/plugin-terser': 0.4.4(rollup@2.79.2)


### PR DESCRIPTION
## Description

🔙 Add Rollback Support to Release Workflow

This PR introduces a new GitHub Actions workflow that allows maintainers to rollback the main branch to a specific commit.  
It performs a hard reset, deletes any tags and associated GitHub Releases created after the target commit, and force-pushes the updated state.

Other changes:
- 📦 add devDep - @actions/github@6.0.0
- 👷 update bounty/thank-you workflow to use setup composite action

## Related Issues
- No rollback strategy and mechanism to a certain commit hash

## Changes Made

- [x] Feature added
- [ ] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

In your own fork, run the github action workflow `🔙 Rollback` and input the commit hash you want your default branch to rollback to. Observe that the HEAD is now at the commit hash and all of the tags/releases ahead of the commit hash are all deleted

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
