### PR TITLE
fix(ci): 🐛 nx release correctly derives next prerelease version based on conventional commits

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -55,7 +55,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pnpm nx:release version prerelease --preid ${{ github.event.inputs.pre-id }}
+          pnpm nx:release version --preid ${{ github.event.inputs.pre-id }}
 
           # Use this locally when you've manually bumped a prerelease (e.g. 0.0.1-alpha.0 → 0.1.0-alpha.0, patch prerelease → minor prerelease)
           # Generates changelog from last *stable* tag up to current prerelease version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,13 +11,12 @@ on:
         options:
           - latest
           - next
-
-  push:
-    tags:
-      - "v*.*.*" # stable
-      - "v*.*.*-alpha.*" # alpha prerelease
-      - "v*.*.*-beta.*" # beta prerelease
-      - "v*.*.*-rc.*" # rc prerelease
+  # push:
+  #   tags:
+  #     - "v*.*.*" # stable
+  #     - "v*.*.*-alpha.*" # alpha prerelease
+  #     - "v*.*.*-beta.*" # beta prerelease
+  #     - "v*.*.*-rc.*" # rc prerelease
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

- nx release correctly derives next prerelease version based on conventional commits
- disable automatic npm publishing temporarily

## Related Issues

- nx release was incorrectly derives next prerelease version based on conventional commits

Sources for fix:
- https://github.com/nrwl/nx/issues/22150
- https://github.com/nrwl/nx/discussions/23387#discussioncomment-11230516 - the comment with the actual fix 

## Changes Made

- [ ] Feature added
- [x] Bug fixed
- [ ] Code refactored
- [ ] Documentation updated

## How to Test

Run the pre-release workflow in your fork after making a conventional commit and observe it will increment to correct next version based on conventional commits

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been added/updated if needed
- [x] Documentation has been updated if necessary
- [x] Ready for review 🚀
