### PR TITLE
fix(ci): 👷 use pull_request event to correctly checkout forked PR code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@
 name: ♻️ CI Workflow
 run-name: "♻️ CI Workflow - PR #${{ github.event.pull_request.number }} commit ${{ github.sha }} by @${{ github.actor }}"
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "*"
 


### PR DESCRIPTION
## Description

switched from `pull_request_target` to `pull_request` event in the CI workflow. this ensures the workflow runs using the forked PR code instead of the base repo code, preventing false positives and simplifying branch checkout logic.

## Related Issues

n/a

## Changes Made

* [x] Bug fixed

## How to Test

1. open a PR from a forked repo
2. confirm that CI jobs use the correct commit (PR head, not base branch)
3. ensure build/lint/test jobs run against the expected code

## Checklist

* [x] Code follows project style guidelines
* [x] Tests have been added/updated if needed
* [x] Documentation has been updated if necessary
* [x] Ready for review 🚀
