### PR TITLE
fix(ci): 👷 checkout PR head from fork in pull_request_target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@
 name: ♻️ CI Workflow
 run-name: "♻️ CI Workflow - PR #${{ github.event.pull_request.number }} commit ${{ github.sha }} by @${{ github.actor }}"
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - "*"
 
@@ -23,7 +23,9 @@ jobs:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Fetch all history for all branches and tags
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup
 


### PR DESCRIPTION
## Description

ensures ci runs against the fork's pr code instead of the base branch when triggered by `pull_request_target`. by default, `actions/checkout` grabs the base repo’s default branch — this explicitly checks out the correct fork + branch via `github.event.pull_request.head`.

## Related Issues

n/a

## Changes Made

* [x] Bug fixed

## How to Test

* open a pr from a forked repo
* verify that ci jobs run against the fork’s code (e.g. check logs for correct commit sha)
* no need to merge; the job output should confirm proper checkout

## Checklist

* [x] Code follows project style guidelines
* [x] Ready for review 🚀