### PR TITLE
fix(ci): 👷 checkout correct PR head from fork in all jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 1
+          fetch-depth: 0 # Fetch all history for all branches and tags
 
       - uses: ./.github/actions/setup
 
@@ -42,6 +42,8 @@ jobs:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
 
       - uses: ./.github/actions/setup
@@ -63,6 +65,8 @@ jobs:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
 
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## Description

fixes incorrect code checkout in `pull_request_target` workflows. previously, only the `commit-lint` job correctly checked out the forked pr code. the `build-typecheck-lint` and `test` jobs were still checking out the base repo’s default branch, leading to inaccurate ci results. this change ensures *all* jobs use `github.event.pull_request.head` to fetch the correct branch from the fork.

## Related Issues

n/a

## Changes Made

* [x] Bug fixed

## How to Test

* open a pr from a fork
* verify all jobs (`commit-lint`, `build-typecheck-lint`, `test`) checkout and run against the correct commit/branch from the fork
* check that the logs show the correct repo and commit sha from the pr head

## Checklist

* [x] Code follows project style guidelines
* [x] Tests have been added/updated if needed
* [x] Documentation has been updated if necessary
* [x] Ready for review 🚀